### PR TITLE
fix for goto position == 0 resulting in "coordinates missing"

### DIFF
--- a/webserver/WebServer.js
+++ b/webserver/WebServer.js
@@ -204,7 +204,7 @@ const WebServer = function(options) {
     });
     
     this.app.put("/api/go_to", function(req,res) {
-        if(req.body && req.body.x && req.body.y) {
+        if(req.body && req.body.x !== undefined && req.body.y !== undefined) {
             self.vacuum.goTo(req.body.x, req.body.y, function(err,data) {
                 if(err) {
                     res.status(500).send(err.toString());


### PR DESCRIPTION
fixing a bug:
position x and or y equal to 0 (which is the origin) was not allowed