### PR TITLE
Build automatically using travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+node_js:
+- '9'
+dist: trusty
+sudo: true
+
+install:
+- npm install
+
+script:
+- "./node_modules/.bin/pkg --targets latest-linux-armv7 --no-bytecode --public-packages=exif-parser,omggif,trim,prettycron ."
+
+deploy:
+  provider: releases
+  api_key:
+    secure: <add your encrypted personal access token here>
+  file: "valetudo"
+  skip_cleanup: true
+  on:
+    branch: master
+    tags: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Valetudo - Free your vacuum from the cloud
 
+[![Build Status](https://travis-ci.com/Nebukadneza/Valetudo.svg?branch=master)](https://travis-ci.com/Nebukadneza/Valetudo)
+
 Valetudo provides all settings and controls of the Xiaomi Vacuum in a mobile-friendly webinterface.
 It runs directly on the vacuum and requires no cloud connection whatsoever.
 

--- a/deployment/Readme.md
+++ b/deployment/Readme.md
@@ -1,13 +1,16 @@
 I'f you're using this in a network somewhere in 10.0.0.0/8 you may want to think this through.
 
 
-For building, pkg and a raspberry pi (3 ?) is needed since the pi is armv7
+For building, you need a reasonably new NodeJS. You can install this from your
+distro (preferred), or using one of the official pre-compiled binaries on the
+node-website …. `pkg` is able to create armv7-binaries on x86 (and other
+platforms) just fine — as long as it doesn’t need to pre-compile its JS
+bytecode. This is why we specify `--no-bytecode`.
 ```
-npm install -g pkg
 git clone http://github.com/hypfer/Valetudo
 cd Valetudo
 npm install
-pkg --targets latest-linux-armv7 .
+./node_modules/.bin/pkg --targets latest-linux-armv7 --no-bytecode --public-packages=exif-parser,omggif,trim,prettycron ."
 ```
 After that you'll find a binary named valetudo in that folder which you should scp to /usr/local/bin/
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Self-contained control webinterface for xiaomi vacuum robots",
   "main": "index.js",
   "bin": "index.js",
+  "license": "Apache-2.0",
   "pkg": {
     "assets": [
       "client/**/*"
@@ -18,6 +19,9 @@
     "compression": "^1.7.2",
     "express": "^4.16.3",
     "jimp": "0.3.2",
-    "prettycron": "git+https://github.com/azza-bazoo/prettycron.git"
+    "prettycron": "^0.10.0"
+  },
+  "devDependencies": {
+    "pkg": "^4.3.4"
   }
 }


### PR DESCRIPTION
This PR helps automatically building valetudo using Travis-CI.

Building automatically is possible because `pkg` will package a armv7-nodejs-binary with the valetudo-source and its dependencies just fine … as long as we tell it not to pre-compile bytecode. As pre-compiled bytecode in node only adds a minor speed improvement for valetudo in my experience, and has virtually no impact on file-size, this seems reasonable to me.

Now, for all this to work nicely, we need a bit of support from @Hypfer as the repo owner. If i remember right, you’d need to:
* Activat and authorize travis-ci for this repo
* Create a personal access token on github (your profile ⇒ edit profile ⇒ developer settings ⇒ personal access token)
* Encrypt your token using https://docs.travis-ci.com/user/encryption-keys/, or by using the `travis` CLI tool.
* Add your token to `.travis.yml` at `deploy.api_key.secure` (I left a marker there)
* Change the URLs for the badge in `Readme.md`
* Tag a commit in the master branch, and push this commit + its tag

From there on, all tagged commits in master will get built and released by travis. All branches and PRs will get built, but not released — their build-artifacts will not get archived anywhere AFAIK. But at least we’ll know they build ^_^.

You can check my example release created this way here:
https://github.com/Nebukadneza/Valetudo/releases
and it’s builds here:
https://travis-ci.com/Nebukadneza/Valetudo

I really hope this helps everyone here, and helps speeding up the process of releasing binaries for us users out there ….