### PR TITLE
Scan newest folder first

### DIFF
--- a/webserver/WebServer.js
+++ b/webserver/WebServer.js
@@ -911,7 +911,7 @@ WebServer.FIND_LATEST_MAP_IN_ARCHIVE = function(callback) {
                     folders.push(filename);
                 }
             });
-            folders = folders.sort();
+            folders = folders.sort().reverse();
 
             let newestUsableFolderName;
             let mapFileName;


### PR DESCRIPTION
Following my pull request https://github.com/Hypfer/Valetudo/pull/59, I noticed a new bug arising where an older map would be shown. 
This is because ` folders = folders.sort(); ` sorts the directory names in ascending order. However, the newest folder would be found if sorted by descending order.

I am unsure if the same would be needed for `possibleMapFileNames = possibleMapFileNames.sort();`, so I didn't push this change yet.