### PR TITLE
Change config file location to /mnt/data

### DIFF
--- a/Valetudo.js
+++ b/Valetudo.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const Vacuum = require("./miio/Vacuum");
 const Webserver = require("./webserver/WebServer");
 
-const defaultConfigFileLocation = "/etc/valetudo/config.json"
+const defaultConfigFileLocation = "/mnt/data/valetudo/config.json"
 
 const Valetudo = function() { 
     this.address = process.env.VAC_ADDRESS ? process.env.VAC_ADDRESS : "127.0.0.1";

--- a/webserver/WebServer.js
+++ b/webserver/WebServer.js
@@ -16,7 +16,7 @@ const MapFunctions = require("../client/js/MapFunctions");
 const chargerImagePath = path.join(__dirname, '../client/img/charger.png');
 const robotImagePath = path.join(__dirname, '../client/img/robot.png');
 
-const defaultConfigFileLocation = "/etc/valetudo/config.json"
+const defaultConfigFileLocation = "/mnt/data/valetudo/config.json"
 
 /**
  *


### PR DESCRIPTION
If you flash a new firmware, the config in /etc/valetudo will be gone.
We should use the persitant flash memory for that.