### PR TITLE
Added Valetudo release number to Settings>Info

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1709,6 +1709,14 @@
                         ???
                     </div>
                 </ons-list-item>
+                <ons-list-item>
+                    <div class="left">
+                        Valetudo version:
+                    </div>
+                    <div class="right" id="info_valetudo_version">
+                        ???
+                    </div>
+                </ons-list-item>
             </ons-list>
 
 
@@ -1716,6 +1724,7 @@
                 var loadingBarSettingsInfo = document.getElementById('loading-bar-settings-info');
                 var infoFwVer = document.getElementById('info_fw_version');
                 var infoFwBuild = document.getElementById('info_fw_build');
+                var infoValetudoVersion = document.getElementById('info_valetudo_version');
 
                 ons.getScriptPage().onShow = function() {
                     updateSettingsInfoPage();
@@ -1728,6 +1737,7 @@
                         if (!err) {
                             infoFwVer.innerHTML = res.version;
                             infoFwBuild.innerHTML = res.build;
+                            infoValetudoVersion.innerHTML = res.valetudoVersion;
                         } else {
                             ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: 1500 })
                         }

--- a/client/index.html
+++ b/client/index.html
@@ -1685,7 +1685,7 @@
                 <div class="left">
                     <ons-back-button>Settings</ons-back-button>
                 </div>
-                <div class="center">Wifi</div>
+                <div class="center">Info</div>
                 <div class="right">
                 </div>
             </ons-toolbar>

--- a/webserver/WebServer.js
+++ b/webserver/WebServer.js
@@ -101,9 +101,18 @@ const WebServer = function(options) {
                 const extractedOsRelease = data.toString().match(WebServer.OS_RELEASE_FW_REGEX);
                 if (extractedOsRelease) {
                     const splittedFw = extractedOsRelease[11].split('_');
+                    //determine package.json
+                    var rootDirectory = path.resolve(__dirname, "..");
+                    var packageContent = fs.readFileSync(rootDirectory + '/package.json');
+                    var valetudoVersion = "?"; //Could not read ../package.json
+                    if (packageContent) {
+                        valetudoVersion = JSON.parse(packageContent).version;
+                    }
+                    //return result
                     res.json({
                         version: splittedFw[0],
-                        build: splittedFw[1]
+                        build: splittedFw[1],
+                        valetudoVersion
                     });
                 }
             }


### PR DESCRIPTION
This commit enables user to determine, which valetudo version is installed. Therefore, the "Settings>Info" got extended by "Valetudo version". This number is automatically read out of the "package.json", so no additional maintenance required for this feature.

![image](https://user-images.githubusercontent.com/13197758/52535306-fa343280-2d4c-11e9-8817-22113f1e179f.png)
