### PR TITLE
build(TravisCI): upgrade Node.js version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: node_js
 node_js:
-- '9'
+  - lts/*
 dist: trusty
 sudo: true
 
 install:
-- npm install
+  - npm install
 
 script:
-- "./node_modules/.bin/pkg --targets node8-linux-armv7 --no-bytecode --options max-old-space-size=72 --public-packages=exif-parser,omggif,trim,prettycron,mqtt ."
+  - "./node_modules/.bin/pkg --targets node8-linux-armv7 --no-bytecode --options max-old-space-size=72 --public-packages=exif-parser,omggif,trim,prettycron,mqtt ."
 
 deploy:
   provider: releases


### PR DESCRIPTION
Node.js 9 is already EOL. The lts/* version always uses the latest LTS version (currently 10.15.3), the target version from the build command remains unchanged.