### PR TITLE
Add stat for the latest clean in publish attributes

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -197,7 +197,7 @@ MqttClient.prototype.updateAttributesTopic = function() {
                                 duration: data[0][2],
                                 area: (data[0][3] / 1000000).toFixed(1),
                                 errorCode: data[0][4],
-                                errorDescription: this.vacuum.getErrorCodeDescription(data[0][4]),
+                                errorDescription: Vacuum.GET_ERROR_CODE_DESCRIPTION(data[0][4]),
                                 finishedFlag: (data[0][5] === 1)
                               };
                             } else {

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -187,6 +187,26 @@ MqttClient.prototype.updateAttributesTopic = function() {
                         response.cleanTime = (res2[0] / 60 / 60).toFixed(1);
                         response.cleanArea = (res2[1] / 1000000).toFixed(1);
                         response.cleanCount = res2[2];
+                        var last_runs = res2[3];
+                        if (last_runs.length > 0) {
+                          this.vacuum.getCleanRecord(last_runs[0], (err, data) => {
+                            if (err == null) {
+                              this.last_run_stats = {
+                                startTime: data[0][0] * 1000, //convert to ms
+                                endTime: data[0][1] * 1000, //convert to ms
+                                duration: data[0][2],
+                                area: (data[0][3] / 1000000).toFixed(1),
+                                errorCode: data[0][4],
+                                errorDescription: this.vacuum.getErrorCodeDescription(data[0][4]),
+                                finishedFlag: (data[0][5] === 1)
+                              };
+                            } else {
+                              //TODO: needs more error handling
+                              console.error(err);
+                            }
+                          });
+                        }
+                        response.last_run_stats = this.last_run_stats ? this.last_run_stats : {};
                         response.mainBrush = (Math.max(0, 300 - (res.main_brush_work_time / 60 / 60))).toFixed(1);
                         response.sideBrush = (Math.max(0, 200 - (res.side_brush_work_time / 60 / 60))).toFixed(1);
                         response.filter = (Math.max(0, 150 - (res.filter_work_time / 60 / 60))).toFixed(1);


### PR DESCRIPTION
To make the life easier for my homeassistant card I need the get the status of the last clean added into published mqtt attributes.

At the first run, or if no clean's exists we have an empty last_run_stats:
-- snipp mqtt record --
valetudo/shou-lee/attributes {"cleanTime":"103.0","cleanArea":"5974.8","cleanCount":181,"last_run_stats":{},"mainBrush":"196.6","sideBrush":"96.6","filter":"46.6","sensor":"0.0"}

If we have stats it will be added into last_run_stats:
-- snipp mqtt record --
valetudo/shou-lee/attributes {"cleanTime":"103.0","cleanArea":"5974.8","cleanCount":181,"last_run_stats":{"startTime":1554527701000,"endTime":1554529164000,"duration":0,"area":"26.9","errorCode":0,"errorDescription":"No error","finishedFlag":false},"mainBrush":"196.6","sideBrush":"96.6","filter":"46.6","sensor":"0.0"}