### PR TITLE
feat: add MQTT over TLS (mqtts) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The Valetudo binary however does not so if you are upgrading your firmware, you 
 * Go-To
 * Zoned Cleanup
 * Configure Timers
-* MQTT
+* MQTT (including TLS support)
 * MQTT HomeAssistant Autodiscovery
 * Start/Stop/Pause Robot
 * Find Robot/Send robot to charging dock

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -16,7 +16,8 @@ const Configuration = function() {
             topicPrefix: "valetudo",
             autoconfPrefix: "homeassistant",
             broker_url: "mqtt://user:pass@foobar.example",
-            provideMapData: true
+            provideMapData: true,
+            caPath: ""
         },
         "dummycloud": {
             spoofedIP: "203.0.113.1",

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -1,7 +1,7 @@
+const fs = require("fs");
 const mqtt = require("mqtt");
 const Tools = require("./Tools");
 const Vacuum = require("./miio/Vacuum");
-
 
 const COMMANDS = {
     turn_on: "turn_on",
@@ -44,6 +44,7 @@ const MqttClient = function(options) {
     this.autoconfPrefix = options.autoconfPrefix || "homeassistant";
     this.attributesUpdateInterval = options.attributesUpdateInterval || 60000;
     this.provideMapData = options.provideMapData !== undefined || true;
+    this.caPath = options.caPath || "";
     this.events = options.events;
 
     this.topics = {
@@ -109,7 +110,11 @@ const MqttClient = function(options) {
 
 MqttClient.prototype.connect = function() {
     if(!this.client || (this.client && this.client.connected === false && this.client.reconnecting === false)) {
-        this.client = mqtt.connect(this.brokerURL);
+        const options = {};
+        if (this.caPath) {
+            options.ca = fs.readFileSync(this.caPath);
+        }
+        this.client = mqtt.connect(this.brokerURL, options);
 
         this.client.on("connect", () => {
             this.client.subscribe([

--- a/lib/Valetudo.js
+++ b/lib/Valetudo.js
@@ -51,6 +51,7 @@ const Valetudo = function() {
             topicPrefix: this.configuration.get("mqtt").topicPrefix,
             autoconfPrefix: this.configuration.get("mqtt").autoconfPrefix,
             provideMapData: this.configuration.get("mqtt").provideMapData,
+            caPath: this.configuration.get("mqtt").caPath,
             events: this.events
         });
     }


### PR DESCRIPTION
Added an option to specify the certificate authority (CA) file path to enable mqtts support. One has to copy e.g. the `mosquitto.crt` file from the MQTT broker to the robo. This is working because the mqtt npm package uses Node.js TLS lib which can use a custom CA list: https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options

Example would be:

`    "caPath": "/mnt/data/valetudo/mosquitto.crt"`

This fixes #126. I've successfully used this setup for some weeks.
