### PR TITLE
Fix buttons disable state

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -555,7 +555,7 @@
                                 robotState.innerHTML = res.human_state;
                             }
 
-                            if (res.in_cleaning === 1 || res.in_cleaning === 2) {
+                            if (res.in_cleaning === 1 || res.in_cleaning === 2 || res.state === 11 || res.state === 16) {
                                 if (res.state === 3 || res.state === 10 || res.state === 2) {
                                     pauseButton.setAttribute("disabled", "disabled");
                                     startButton.removeAttribute("disabled");
@@ -575,13 +575,13 @@
                                 }
                             }
 
-                            if (res.state === 8 || res.state === 15 || res.state === 10 || res.state === 3 || res.state === 6) {
+                            if (res.state === 8 || res.state === 15 || res.state === 10 || res.state === 11 || res.state === 3 || res.state === 6 || res.state === 16) {
                                 stopButton.setAttribute("disabled", "disabled");
                             } else {
                                 stopButton.removeAttribute("disabled");
                             }
 
-                            if (res.state === 5 || res.state === 6 || res.state === 8 || res.state === 9) {
+                            if (res.state === 5 || res.state === 6 || res.state === 8 || res.state === 9 ||  res.state === 11 || res.state === 16 || res.state === 17) {
                                 homeButton.setAttribute("disabled", "disabled");
                             } else {
                                 homeButton.removeAttribute("disabled");


### PR DESCRIPTION
In "Going to target" and "Spot cleaning" state robot is not in
in_cleaning. Stop and home buttons are not working, so disable them but
enable pause button, which works.

In "Zone cleaning" state Home button doesn't work, so disable them.

Tested on firmware Gen2 1768. And of course I'm not sure if it's same on other firmware or generations.