### PR TITLE
Limit memory allocation

### DIFF
--- a/deployment/valetudo.conf
+++ b/deployment/valetudo.conf
@@ -8,3 +8,4 @@ oom score 1000
 exec /usr/local/bin/valetudo
 respawn
 respawn limit 10 90
+limit as 209715200 209715200


### PR DESCRIPTION
Process valetudo on robot can sometimes consume a lots of memory (memory
leak?). If this happens, kernel sometimes kill player (instead of valetudo
even with high oom score). So let's limit max memory allocation of valetudo
process to 200 MB, which should be enough. Better is to kill valetudo
than player itself.