### PR TITLE
Align consumable titles vertically

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1867,9 +1867,9 @@
             <ons-progress-bar id="loading-bar-settings-consumables" value="0" indeterminate="indeterminate"></ons-progress-bar>
 
             <ons-list-title style="margin-top:5px;">Consumables</ons-list-title>
-            <ons-list>
+            <ons-list id="consumables-list">
                 <ons-list-item>
-                    <div class="left">
+                    <div class="left consumables-list-item-title">
                         Main Brush
                     </div>
                     <div class="center" id="settings-consumables-status-main-brush" style="margin-left:5%">
@@ -1880,7 +1880,7 @@
                     </div>
                 </ons-list-item>
                 <ons-list-item>
-                    <div class="left">
+                    <div class="left consumables-list-item-title">
                         Side Brush
                     </div>
                     <div class="center" id="settings-consumables-status-side-brush" style="margin-left:5%">
@@ -1891,7 +1891,7 @@
                     </div>
                 </ons-list-item>
                 <ons-list-item>
-                    <div class="left">
+                    <div class="left consumables-list-item-title">
                         Filter
                     </div>
                     <div class="center" id="settings-consumables-status-filter" style="margin-left:5%">
@@ -1902,7 +1902,7 @@
                     </div>
                 </ons-list-item>
                 <ons-list-item>
-                    <div class="left">
+                    <div class="left consumables-list-item-title">
                         Sensor cleaning
                     </div>
                     <div class="center" id="settings-consumables-status-sensor" style="margin-left:5%">
@@ -1992,7 +1992,13 @@
                     });
                 }
             </script>
+            <style>
+                #consumables-list .consumables-list-item-title {
+                    width: 100px;
+                }
+            </style>
         </ons-page>
+
     </template>
 
     <template id="settings-cleaning-history.html">

--- a/client/index.html
+++ b/client/index.html
@@ -1994,7 +1994,7 @@
             </script>
             <style>
                 #consumables-list .consumables-list-item-title {
-                    width: 100px;
+                    width: 130px;
                 }
             </style>
         </ons-page>


### PR DESCRIPTION
This will fix a simple alignment in the consumables settings page

before:
<img width="368" alt="Bildschirmfoto 2019-05-04 um 22 54 12" src="https://user-images.githubusercontent.com/8901210/57184722-dc93e680-6ebf-11e9-922f-75aa1dc3fc49.png">



after:

<img width="365" alt="Bildschirmfoto 2019-05-04 um 22 54 16" src="https://user-images.githubusercontent.com/8901210/57184723-def64080-6ebf-11e9-901e-745c88a89ecf.png">
