### PR TITLE
Add a basic HTTP status notifier

### DIFF
--- a/lib/HttpNotifier.js
+++ b/lib/HttpNotifier.js
@@ -34,14 +34,21 @@ HttpNotifier.prototype.postStatus = function(statusData) {
         headers: {'Content-Type': 'application/json'}
     };
 
-    const req = http.request(options, (res) => {});
-    
+    let req = null;
     try {
+        req = http.request(options);
+        req.on('error', () => {});
+
         const stringified = JSON.stringify(statusData);
-        req.write(stringified);
-    } catch (e) {
-    } finally {
+        if (stringified) {
+            req.write(stringified);
+        }
+        
         req.end();
+    } catch (e) {
+        if (req) {
+            req.abort();
+        }
     }
 };
 

--- a/lib/HttpNotifier.js
+++ b/lib/HttpNotifier.js
@@ -1,0 +1,48 @@
+const http = require('http');
+const urllib = require('url');
+
+/**
+ *
+ * @param options {object}
+ * @param options.configuration {Configuration}
+ * @param options.events {EventEmitter}
+ * @constructor
+ */
+const HttpNotifier = function(options) {
+    this.configuration = options.configuration;
+
+    let notificationConfig = this.configuration.get('http-status-notifications');
+
+    this.notificationURL = notificationConfig.url;
+    this.events = options.events;
+
+    this.events.on("miio.status", (statusData) => {
+        console.log(`Posting status to ${this.notificationURL}`);
+        this.postStatus(statusData);
+    });
+};
+
+HttpNotifier.prototype.postStatus = function(statusData) {
+    const components = new urllib.URL(this.notificationURL);
+
+    const options = {
+        method: 'POST',
+        host: components.hostname,
+        port: components.port,
+        path: components.pathname,
+        protocol: components.protocol,
+        headers: {'Content-Type': 'application/json'}
+    };
+
+    const req = http.request(options, (res) => {});
+    
+    try {
+        const stringified = JSON.stringify(statusData);
+        req.write(stringified);
+    } catch (e) {
+    } finally {
+        req.end();
+    }
+};
+
+module.exports = HttpNotifier;

--- a/lib/Valetudo.js
+++ b/lib/Valetudo.js
@@ -3,6 +3,7 @@ const Vacuum = require("./miio/Vacuum");
 const Dummycloud = require("./miio/Dummycloud");
 const Webserver = require("./webserver/WebServer");
 const MqttClient = require("./MqttClient");
+const HttpNotifier = require("./HttpNotifier");
 const Configuration = require("./Configuration");
 const MapDTO = require("./dtos/MapDTO");
 const EventEmitter = require('events');
@@ -80,6 +81,14 @@ const Valetudo = function() {
             map: this.map
         });
     }
+
+    if(this.configuration.get("http-status-notifications") && this.configuration.get("http-status-notifications").url) {
+        this.httpNotifier = new HttpNotifier({
+            configuration: this.configuration,
+            events: this.events
+        });
+    }
+
 };
 
 Valetudo.NATIVE_TOKEN_PROVIDER = function() {


### PR DESCRIPTION
There are no means of getting Vacuums status without polling it constantly or setting up MQTT, so I implemented a basic status notifier that `POST`s the status over HTTP to a URL defined in the configuration.

Example entry in `/mnt/data/valetudo.config.json`:

```
"http-status-notifications": {
    "url": "http://192.168.0.116:52199/status"
}
```

I admit this pull request is a little selfish, because I need such functionality for [my own thing](https://github.com/onfoot/homebridge-valetudo-xiaomi-vacuum) - I hate to bother the poor overloaded vacuum with constant status polls, so a push would be nice instead. ;)

It could also be used to send push notifications through e.g. Pushover or execute webhooks in IFTTT. I know Valetudo is all about freeing the Vacuum from the "cloud", but we can make it work in the "clouds" we kind of control. ;)

If you like it, and have any ideas on how to make it more complete, or perhaps more stable and crash resistant, let me know!