### PR TITLE
add api route to store virtual walls / nogo zones

### DIFF
--- a/lib/miio/Vacuum.js
+++ b/lib/miio/Vacuum.js
@@ -591,7 +591,48 @@ Vacuum.prototype.startCleaningZone = function(zones, callback) {
     } else {
         callback(new Error("Zones must be array of at most 5 zones."))
     }
+};
 
+/**
+ * Saves the persistent data like virtual walls and nogo zones
+ * @param persistentData is an array of walls / zones
+ * They have to be provided in the following format:
+ *      https://github.com/marcelrv/XiaomiRobotVacuumProtocol/issues/15#issuecomment-447647905
+ *      Software barrier takes a vector of [id, x1,y1,x2,y2]
+ *      And no-go zone takes [id, x1,y1,x2,y2,x3,y3,x4,y4], which are the corners of the zone rectangle?
+ *      Edit: see @JensBuchta's comment. The first parameter appears to be a type: 0 = zone, 1 = barrier
+ */
+Vacuum.prototype.savePersistentData = function(persistantData, callback) {
+    if(Array.isArray(persistantData)) {
+        const flippedYCoordinates = persistantData.map(data => {
+            if(data[0] === 0) {
+                // this is a zone
+                return [
+                    data[0],
+                    data[1],
+                    Tools.DIMENSION_MM - data[2],
+                    data[3],
+                    Tools.DIMENSION_MM - data[4],
+                    data[5],
+                    Tools.DIMENSION_MM - data[6],
+                    data[7],
+                    Tools.DIMENSION_MM - data[8]
+                ];
+            } else {
+                // this is a barrier
+                return [
+                    data[0],
+                    data[1],
+                    Tools.DIMENSION_MM - data[2],
+                    data[3],
+                    Tools.DIMENSION_MM - data[4],
+                ];
+            }
+        });
+
+        this.sendMessage("save_map", flippedYCoordinates, {}, callback);
+    }
+    else callback(new Error("persistantData has to be an array."));
 };
 
 /**

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -512,6 +512,29 @@ const WebServer = function (options) {
         }
     });
 
+    this.app.put("/api/persistent_data", function (req, res) {
+        if( req.body != undefined
+            && Array.isArray(req.body.virtual_walls)
+            && Array.isArray(req.body.no_go_areas)
+        ) {
+            const persistentData = [
+                ...req.body.no_go_areas.map(area => [0, ...area]),
+                ...req.body.virtual_walls.map(wall => [1, ...wall])
+            ];
+
+            self.vacuum.savePersistentData(persistentData, function(err) {
+                if(err) {
+                    console.log(err);
+                    res.status(500).json(err);
+                } else {
+                    res.status(201).json({message: "ok"});
+                }
+            });
+        } else {
+            res.status(400).send({message: "bad request body. Should look like { \"virtual_walls\": [], \"no_go_areas\": []}"});
+        }
+    });
+
     this.app.get("/api/spots", function (req, res) {
         const spots = self.configuration.get("spots");
 


### PR DESCRIPTION
The endpoint accepts the same format the /api/map/latest map is generating.

```
{
	"no_go_areas": [
        [
            27200,
            30850,
            27950,
            30850,
            27950,
            31250,
            27200,
            31250
        ]
    ],
    "virtual_walls": [
        [
            20512,
            27340,
            20512,
            28590
        ]
    ]
}
```