### PR TITLE
reset the line dash when drawing predicted path

### DIFF
--- a/client/zone/js-modules/path-drawer.js
+++ b/client/zone/js-modules/path-drawer.js
@@ -143,6 +143,7 @@ export function PathDrawer() {
             ctx.setLineDash([5, 5]);
             drawLines(predictedPath.points, ctx);
             ctx.stroke();
+            ctx.setLineDash([]);
         }
     }
 


### PR DESCRIPTION
Currently all the path is becoming dashed after a while if there is a predicted path to be rendered.
This commit fixes this by resetting the "line dash" to solid.