### PR TITLE
Install voice packs through valetudo

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -2517,13 +2517,16 @@
                         }, function (err, res){
                             if(err){
                                 ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: 1500 });
+                                voicePackUploadButton.innerText = uploadText;
+                                voicePackUploadButton.disabled = false;
+                                loadingBarSettingsSoundVolume.value = 0;
                             }else{
                                 voicePackUploadButton.innerText = 'Installing voice pack...';
                                 getVoicePackInstallStatus(function(err, data){
                                     if(!err){
                                         loadingBarSettingsSoundVolume.value = 90 + (data.progress * 0.1);
 
-                                        if(data.progress == 100){
+                                        if(data.progress == 100 || data.error != 0){
                                             if(data.error != 0){
                                                 ons.notification.toast("Failed to install voice pack.", { buttonLabel: 'Dismiss', timeout: 1500 });
                                             }else{
@@ -2547,7 +2550,6 @@
                 function getVoicePackInstallStatus(callback){
                     setTimeout(function(){
                         fn.request("api/install_voice_pack_status", "GET", function (err, res) {
-                            res = res[0];
                             callback(err, res);
                             if(!err){
                                 if(res.progress != 100 && res.error == 0){

--- a/client/index.html
+++ b/client/index.html
@@ -88,6 +88,38 @@
             };
         };
 
+        window.fn.postFile = function (url, path, progressCallback, callback){
+            var formData = new FormData();
+            formData.append("file", path);
+
+            var request = new XMLHttpRequest();
+            request.onerror = function(e) {
+                console.error(request);
+                callback("There was an error: " + request.status);
+            };
+        
+            request.onload = function(e) {
+                if (request.status >= 200 && request.status < 400) {
+                    callback(null, JSON.parse(request.responseText));
+                } else {
+                    console.error(request);
+                    callback("There was an error: " + request.status);
+                }
+            };
+
+            request.upload.onprogress = function(e) {
+                var p = Math.round(100 / e.total * e.loaded);
+                progressCallback(p);
+            };
+
+            request.onerror = function () {
+                callback("Connection error");
+            };
+
+            request.open("POST", url);
+            request.send(formData);
+        }        
+
         window.fn.secondsToHms = function (d) {
             d = Number(d);
 
@@ -1588,9 +1620,9 @@
                 <div class="title"><ons-icon icon="fa-key"></ons-icon> Token</div>
                 <div class="content">View the current token</div>
             </ons-card>
-            <ons-card onclick="fn.pushPage({'id': 'settings-sound-volume.html', 'title': 'Sound Volume'})">
-                <div class="title"><ons-icon icon="fa-volume-up"></ons-icon> Sound Volume</div>
-                <div class="content">Change the sound volume</div>
+            <ons-card onclick="fn.pushPage({'id': 'settings-sound-voice.html', 'title': 'Sound & Voice'})">
+                <div class="title"><ons-icon icon="fa-volume-up"></ons-icon> Sound & Voice</div>
+                <div class="content">Change the sound volume and the voice of the robot</div>
             </ons-card>
             <ons-card onclick="fn.pushPage({'id': 'settings-access-control.html', 'title': 'Access Control'})">
                 <div class="title"><ons-icon icon="fa-lock"></ons-icon> Access Control</div>
@@ -2353,17 +2385,17 @@
         </ons-page>
     </template>
 
-    <template id="settings-sound-volume.html">
-        <ons-page id="settings-sound-volume">
+    <template id="settings-sound-voice.html">
+        <ons-page id="settings-sound-voice">
             <ons-toolbar>
                 <div class="left">
                     <ons-back-button>Settings</ons-back-button>
                 </div>
-                <div class="center">Sound Volume</div>
+                <div class="center">Sound Volume & Voice Pack</div>
                 <div class="right">
                 </div>
             </ons-toolbar>
-            <ons-progress-bar id="loading-bar-settings-sound-volume" value="0" indeterminate="indeterminate"></ons-progress-bar>
+            <ons-progress-bar id="loading-bar-settings-sound-voice" value="0" indeterminate="indeterminate"></ons-progress-bar>
 
             <ons-list-title style="margin-top:20px;">Sound Volume Settings</ons-list-title>
             <ons-list>
@@ -2377,7 +2409,7 @@
                                  <ons-icon icon="md-volume-down"></ons-icon>
                              </ons-col>
                              <ons-col>
-                                 <ons-range style="width: 100%;" value="0" id="settings-sound-volume-input-volume"></ons-range>
+                                 <ons-range style="width: 100%;" value="0" id="settings-sound-voice-input-volume"></ons-range>
                              </ons-col>
                              <ons-col width="40px" style="text-align: center; line-height: 31px;">
                                  <ons-icon icon="md-volume-up"></ons-icon>
@@ -2387,21 +2419,40 @@
                 </ons-list-item>
                 <ons-list-item>
                     <div class="center">
-                        <ons-button id="settings-sound-volume-input-save-button" modifier="large" class="button-margin" onclick="handleSoundVolumeSettingsSaveButton();">Save sound volume</ons-button>
+                        <ons-button id="settings-sound-voice-input-save-button" modifier="large" class="button-margin" onclick="handleSoundVolumeSettingsSaveButton();">Save sound volume</ons-button>
                     </div>
                 </ons-list-item>
                 <ons-list-item>
                     <div class="center">
-                        <ons-button id="settings-sound-volume-input-test-button" modifier="large" class="button-margin" onclick="handleSoundVolumeSettingsTestButton();">Test sound volume</ons-button>
+                        <ons-button id="settings-sound-voice-input-test-button" modifier="large" class="button-margin" onclick="handleSoundVolumeSettingsTestButton();">Test sound volume</ons-button>
                     </div>
                 </ons-list-item>
             </ons-list>
+            <ons-list-title style="margin-top:20px;">Install Voice Pack</ons-list-title>
+            <ons-list>
+                <form id="voice-upload-form">
+                    <ons-list-item>
+                            <div class="left">
+                                Voice Pack File:
+                            </div>
+                            <input id="settings-sound-voice-upload-browser" type="file" placeholder="" size="50" accept=".pkg"></input>
+                    </ons-list-item>
+                    <ons-list-item>
+                        <div class="center">
+                            <button id="settings-sound-voice-upload-pack-button" modifier="large" class="button-margin button button--large" type="submit">Upload Voice Pack</button>
+                        </div>
+                    </ons-list-item>
+                </form>
+            </ons-list>
 
             <script>
-                var loadingBarSettingsSoundVolume = document.getElementById('loading-bar-settings-sound-volume');
-                var soundVolumeInputVolume = document.getElementById('settings-sound-volume-input-volume');
+                var loadingBarSettingsSoundVolume = document.getElementById('loading-bar-settings-sound-voice');
+                var soundVolumeInputVolume = document.getElementById('settings-sound-voice-input-volume');
 
-                var soundVolumeInputSaveButton = document.getElementById('settings-sound-volume-input-save-button');
+                var soundVolumeInputSaveButton = document.getElementById('settings-sound-voice-input-save-button');
+                var voiceUploadForm = document.getElementById('voice-upload-form');
+                var voicePackUploadButton = document.getElementById('settings-sound-voice-upload-pack-button');
+                var voicePackFileBrowser = document.getElementById('settings-sound-voice-upload-browser');
 
                 ons.getScriptPage().onShow = function() {
                     updateSettingsSoundVolumePage();
@@ -2449,6 +2500,62 @@
                             ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: 1500 })
                         }
                     });
+                }
+
+                voiceUploadForm.onsubmit = function(event){
+                    event.preventDefault();
+                    var file = voicePackFileBrowser.files[0];
+                    if(file == undefined){
+                        ons.notification.toast("Please select a voice pack before uploading.", { buttonLabel: 'Dismiss', timeout: 1500 });
+                    }else{
+                        loadingBarSettingsSoundVolume.removeAttribute("indeterminate");
+                        voicePackUploadButton.disabled = true
+                        var uploadText = voicePackUploadButton.innerText;
+                        voicePackUploadButton.innerText = 'Uploading voice pack...';
+                        fn.postFile("api/install_voice_pack", file, function (p){
+                            loadingBarSettingsSoundVolume.value = (p * 0.9);
+                        }, function (err, res){
+                            if(err){
+                                ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: 1500 });
+                            }else{
+                                voicePackUploadButton.innerText = 'Installing voice pack...';
+                                getVoicePackInstallStatus(function(err, data){
+                                    if(!err){
+                                        loadingBarSettingsSoundVolume.value = 90 + (data.progress * 0.1);
+
+                                        if(data.progress == 100){
+                                            if(data.error != 0){
+                                                ons.notification.toast("Failed to install voice pack.", { buttonLabel: 'Dismiss', timeout: 1500 });
+                                            }else{
+                                                ons.notification.toast("Voice pack was successfully installed.", { buttonLabel: 'Dismiss', timeout: 1500 });
+                                            }
+                                            voicePackUploadButton.innerText = uploadText;
+                                            voicePackUploadButton.disabled = false;
+                                            loadingBarSettingsSoundVolume.value = 0;
+                                        }
+                                    }else{
+                                        voicePackUploadButton.innerText = uploadText;
+                                        voicePackUploadButton.disabled = false;
+                                        loadingBarSettingsSoundVolume.value = 0;
+                                    }
+                                });
+                            }
+                        });
+                    }
+                }
+
+                function getVoicePackInstallStatus(callback){
+                    setTimeout(function(){
+                        fn.request("api/install_voice_pack_status", "GET", function (err, res) {
+                            res = res[0];
+                            callback(err, res);
+                            if(!err){
+                                if(res.progress != 100 && res.error == 0){
+                                    getVoicePackInstallStatus(callback);
+                                }
+                            }
+                        });
+                    }, 1000);
                 }
             </script>
         </ons-page>

--- a/lib/miio/Vacuum.js
+++ b/lib/miio/Vacuum.js
@@ -412,6 +412,43 @@ Vacuum.prototype.configureWifi = function(ssid, password, callback) {
 };
 
 /**
+ * Starts the installation of a new voice pack
+ * Returns an error if there is one as the first parameter of the callback
+ * On success, 2nd param looks like this:
+ *  {
+ *      "progress": 0,
+ *      "state": 0,
+ *      "error": 0  
+ *  }
+ * 
+ * 
+ * @param url {string}
+ * @param md5 {string}
+ * @param callback
+ */
+Vacuum.prototype.installVoicePack = function(url, md5, callback) {
+    this.sendMessage("dnld_install_sound", {"url": url, "md5": md5, "sid": 10000}, {}, callback);
+};
+
+/**
+ * Returns the current voice pack installation status
+ * Returns an error if there is one as the first parameter of the callback
+ * On success, 2nd param looks like this:
+ *  {
+ *      "sid_in_progress": 10000,
+ *      "progress": 100,
+ *      "state": 2,
+ *      "error": 0
+ *  }
+ * 
+ * 
+ * @param callback
+ */
+Vacuum.prototype.getVoicePackInstallationStatus = function(callback) {
+    this.sendMessage("get_sound_progress", [], {}, callback);
+};
+
+/**
  * Returns the current status of the robot
  * Returns an error if there is one as the first parameter of the callback
  * On success, 2nd param looks like this:

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -13,7 +13,8 @@ const RRMapParser = require("../RRMapParser");
 const Vacuum = require("../miio/Vacuum");
 const dynamicMiddleware = require("express-dynamic-middleware");
 const basicAuth = require("express-basic-auth");
-
+const multer = require('multer')
+const upload = multer({ dest: '/tmp/uploads' })
 
 /**
  *
@@ -698,6 +699,53 @@ const WebServer = function (options) {
                 }
             });
         }
+    });
+
+    this.app.get("/api/download_voice_pack", function (req, res){
+        var isLocal = (req.connection.localAddress === req.connection.remoteAddress);
+        if (process.env.NODE_ENV === 'development' || isLocal) {
+            if(self.currentVoicePack){
+                res.download(self.currentVoicePack);
+            }else{
+                res.status(404).send("Not found");
+            }
+        }else{
+            res.status(400).send("Invalid request");
+        } 
+    });
+
+    this.app.post("/api/install_voice_pack", upload.single('file'), function (req, res) {
+        if(req.file){
+            self.currentVoicePack = "/tmp/uploads/pack.pkg";
+            fs.rename(req.file.path, self.currentVoicePack, function (errFs){
+                var vps = fs.createReadStream(self.currentVoicePack);
+                var hash = crypto.createHash('md5').setEncoding('hex');
+                
+                hash.on('finish', function() {
+                    var checksum = hash.read();
+                    self.vacuum.installVoicePack("http://localhost:" + this.port + "/api/download_voice_pack", checksum, function (err, data) {
+                        if (err) {
+                            res.status(500).send(err.toString());
+                        } else {
+                            res.status(200).send(data); 
+                        }
+                    });                      
+                });
+                vps.pipe(hash);
+            });
+       }else{
+            res.status(400).send("Invalid request");
+       }
+    });
+
+    this.app.get("/api/install_voice_pack_status", function(req, res){
+        self.vacuum.getVoicePackInstallationStatus(function(err, data){
+            if(err){
+                res.status(500).send(err.toString());
+            }else{
+                res.status(200).send(data); 
+            }
+        });
     });
 
     this.app.get("/api/map/latest", function (req, res) {

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -14,7 +14,7 @@ const Vacuum = require("../miio/Vacuum");
 const dynamicMiddleware = require("express-dynamic-middleware");
 const basicAuth = require("express-basic-auth");
 const multer = require('multer')
-const upload = multer({ dest: '/tmp/uploads' })
+const upload = multer({ dest: '/mnt/data/valetudo/uploads' })
 
 /**
  *
@@ -42,6 +42,15 @@ const WebServer = function (options) {
     this.app = express();
     this.app.use(compression());
     this.app.use(bodyParser.json());
+
+    this.uploadLocation = "/mnt/data/valetudo/uploads";
+    fs.readdir(this.uploadLocation, (err, files) => {
+        if(!err){ //remove all previous uploads
+            for (const file of files) {
+                fs.unlink(path.join(this.uploadLocation, file), (rmerr) => {});
+            }
+        }
+    });
 
     const authMiddleware = dynamicMiddleware.create(basicAuth({authorizer: function(username, password) {
         const userMatches = basicAuth.safeCompare(username, self.configuration.get("httpAuth").username);
@@ -701,37 +710,45 @@ const WebServer = function (options) {
         }
     });
 
-    this.app.get("/api/download_voice_pack", function (req, res){
-        var isLocal = (req.connection.localAddress === req.connection.remoteAddress);
-        if (process.env.NODE_ENV === 'development' || isLocal) {
-            if(self.currentVoicePack){
-                res.download(self.currentVoicePack);
-            }else{
-                res.status(404).send("Not found");
-            }
-        }else{
-            res.status(400).send("Invalid request");
-        } 
-    });
-
     this.app.post("/api/install_voice_pack", upload.single('file'), function (req, res) {
         if(req.file){
-            self.currentVoicePack = "/tmp/uploads/pack.pkg";
-            fs.rename(req.file.path, self.currentVoicePack, function (errFs){
-                var vps = fs.createReadStream(self.currentVoicePack);
-                var hash = crypto.createHash('md5').setEncoding('hex');
-                
-                hash.on('finish', function() {
-                    var checksum = hash.read();
-                    self.vacuum.installVoicePack("http://localhost:" + this.port + "/api/download_voice_pack", checksum, function (err, data) {
-                        if (err) {
-                            res.status(500).send(err.toString());
-                        } else {
-                            res.status(200).send(data); 
-                        }
-                    });                      
-                });
-                vps.pipe(hash);
+            
+            //Remove old uploads
+            for (const file of fs.readdirSync(self.uploadLocation)) {
+                if(file.endsWith(".pkg"))
+                    fs.unlink(path.join(self.uploadLocation, file), rmerr => {});
+            }
+
+            var tmpname = path.join(self.uploadLocation, path.basename(req.file.path) + ".pkg");
+            fs.rename(req.file.path, tmpname, function (errFs){
+                if(errFs){
+                    res.status(500).send(errFs.toString());
+                    fs.unlink(req.file.path, (delerr) => {});
+                }else{
+                    var vps = fs.createReadStream(tmpname);
+                    var hash = crypto.createHash('md5').setEncoding('hex');
+
+                    hash.on('finish', function() {
+                        self.vacuum.installVoicePack("file://" + tmpname, hash.read(), function (err, data) {
+                            if (err) {
+                                res.status(500).send(err.toString());
+                            } else {
+                                res.status(200).send(data); 
+                            }
+                        });                      
+                    });
+
+                    vps.pipe(hash);
+                                                
+                    //Remove the file after 2 minutes
+                    setTimeout(() => {
+                        fs.exists(tmpname, (exists) => { 
+                            if(exists){ 
+                                fs.unlink(tmpname, (delerr) => {});
+                            }
+                        });
+                    }, 60000);
+                }                
             });
        }else{
             res.status(400).send("Invalid request");
@@ -743,7 +760,7 @@ const WebServer = function (options) {
             if(err){
                 res.status(500).send(err.toString());
             }else{
-                res.status(200).send(data); 
+                res.status(200).send(data[0]); 
             }
         });
     });

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "express-basic-auth": "^1.2.0",
     "express-dynamic-middleware": "^1.0.0",
     "mqtt": "^2.18.8",
+    "multer": "^1.4.1",
     "prettycron": "^0.10.0",
     "ws": "^6.1.4"
   },


### PR DESCRIPTION
This pull request adds an option in the sound settings to upload and install voice packs.
These changes implement "Phase 1" of #165.

**I added ~~3~~ 2 new express endpoints:**
- _POST - /api/install_voice_pack_ - To upload the pkg file
- _GET - /api/install_voice_pack_status_ - To get the current voice pack installation status
~~- _GET - /api/download_voice_pack_ - miio wants some URL to download the language pack from. This endpoint will basically just provide the file that was uploaded using the POST endpoint. For the sake of security it is not possible to access this endpoint from remote addresses in production mode.~~

**I also added 2 new functions in Vaccum.js:**
- _installVoicePack(url, md5, callback)_ - To start the voice pack installation
- _getVoicePackInstallationStatus(callback)_ - To get the status of the voice pack installation

Tested on Gen 2.