### PR TITLE
Make "zone cleanup" more appropriate for HASS.

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -29,7 +29,7 @@ const MQTT_STATES = {
     RETURNING: "returning",
     DOCKED: "docked",
     ERROR: "error",
-    ZONE_CLEANUP: "zone cleanup"
+    ZONE_CLEANUP: "cleaning"
 };
 
 const MQTT_STATE_MAPPINGS = {


### PR DESCRIPTION
"zone cleanup" is not recognized by HASS. Changing this to "cleaning" causes HASS state to change.