### PR TITLE
Don't set password to empty string, keep old one

### DIFF
--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -494,10 +494,15 @@ const WebServer = function (options) {
 
     this.app.put("/api/http_auth_config", function (req, res) {
         if(req.body && typeof req.body === "object" && typeof req.body.enabled === "boolean" && typeof req.body.username === "string" && typeof req.body.password === "string") {
+            pass = req.body.password;
+            if (!pass) {
+                // Don't set password to empty string, keep old one
+                pass = self.configuration.get("httpAuth").password;
+            }
             self.configuration.set("httpAuth", {
                 enabled: req.body.enabled,
                 username: req.body.username,
-                password: req.body.password,
+                password: pass,
             });
             if (self.basicAuthInUse && !req.body.enabled) {
                 authMiddleware.unuse();


### PR DESCRIPTION
If user doesn't provide new password, don't set password to empty
string, but keep old one.