### PR TITLE
Implement https support out of Valetudo

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -28,8 +28,13 @@ const Configuration = function() {
             username: "valetudo",
             password: "valetudo"
         },
-	"allowSSHKeyUpload": true,
-        "map_upload_host": "http://127.0.0.1"
+        "allowSSHKeyUpload": true,
+        "map_upload_host": "http://127.0.0.1",
+        "ssl": {
+            enabled: false,
+            key: "/mnt/data/valetudo/key.key",
+            cert: "/mnt/data/valetudo/cert.crt"
+        }
     };
 
     /* load an existing configuration file. if it is not present, create it using the default configuration */

--- a/lib/Valetudo.js
+++ b/lib/Valetudo.js
@@ -23,7 +23,7 @@ const Valetudo = function() {
         this.tokenProvider = Valetudo.NATIVE_TOKEN_PROVIDER;
     }
 
-    this.webPort = process.env.VAC_WEBPORT ? parseInt(process.env.VAC_WEBPORT) : 80;
+    this.webPort = process.env.VAC_WEBPORT ? parseInt(process.env.VAC_WEBPORT) : this.configuration.get("ssl").enabled ? 443 : 80;
     this.map = new MapDTO({
         parsedData: DEFAULT_MAP
     });

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -1,5 +1,6 @@
 const express = require("express");
 const http = require("http");
+const https = require("https");
 const compression = require("compression");
 const path = require("path");
 const fs = require("fs");
@@ -807,7 +808,19 @@ const WebServer = function (options) {
     });
 
     this.app.use(express.static(path.join(__dirname, "../..", 'client')));
-    const server = http.createServer(this.app);
+
+    const sslConf = this.configuration.get("ssl");
+    let server;
+    if (sslConf.enabled)  {
+        const options = {
+            cert: fs.readFileSync(sslConf.cert),
+            key: fs.readFileSync(sslConf.key)
+        }        
+
+        server = https.createServer(options, this.app);
+    } else {
+        server = http.createServer(this.app);
+    }
 
     const wss = new WebSocket.Server({ server });
 


### PR DESCRIPTION
I implemented a new config section with ssl settings:
```
 "ssl": {
    "enabled": false,
    "key": "/mnt/data/valetudo/roborock.key",
    "cert": "/mnt/data/valetudo/roborock.crt"
  }
```
and also the function of it. If the ssl toggle is switched to `true`. Valetudo will serve its website via `https://` on port `443`.

The frontend behaves very nice and sends all requests now to the secure frontend, but for some reason the map isn't getting any updates anymore. The "No mapdata" map stays there, even if the robot is moving.
Since I'm out of ideas, I hope someone can help me with the map refresh.