### PR TITLE
Fix map with HTTP auth

### DIFF
--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -54,12 +54,22 @@ const WebServer = function (options) {
         }
     });
 
-    const authMiddleware = dynamicMiddleware.create(basicAuth({authorizer: function(username, password) {
+    const basicAuthMiddleware = basicAuth({authorizer: function(username, password) {
         const userMatches = basicAuth.safeCompare(username, self.configuration.get("httpAuth").username);
         const passwordMatches = basicAuth.safeCompare(password, self.configuration.get("httpAuth").password);
 
         return userMatches & passwordMatches;
-    }, challenge: true}));
+    }, challenge: true});
+
+    const authMiddleware = dynamicMiddleware.create(function(req, res, next) {
+        if (['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.ip)) {
+            // Allow requests from localhost
+            next();
+        } else {
+            // Authenticate other ones
+            basicAuthMiddleware(req, res, next);
+        }
+    });
 
     if (this.configuration.get("httpAuth").enabled) {
         this.app.use(authMiddleware.handle());


### PR DESCRIPTION
Dustcloud is uploading map using /api/miio/map_upload_handler. When HTTP
auth is enabled, dustcloud can't upload that map. This patches disable
HTTP auth for requests from localhost.

Closes: #252 