### PR TITLE
simplify map saving

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1682,7 +1682,7 @@
             </ons-card>
             <ons-card onclick="fn.pushPage({'id': 'settings-persistent-data.html', 'title': 'Persistent Maps'})">
                 <div class="title"><ons-icon icon="fa-map"></ons-icon> Persistent Data</div>
-                <div class="content">Configure the lab mode for enabling virtual walls etc.</div>
+                <div class="content">Saves the map, zones and virtual walls.</div>
             </ons-card>
             <ons-card onclick="fn.pushPage({'id': 'settings-consumables.html', 'title': 'Consumables'})">
                 <div class="title"><ons-icon icon="fa-wrench"></ons-icon> Consumables</div>
@@ -1989,13 +1989,16 @@
             <ons-list-title style="margin-top:5px;">Persistent Data Configuration</ons-list-title>
             <ons-row>
                 <ons-col></ons-col>
-                <ons-col width="300px" vertical-align='center' style='text-align:center; max-width: 400px;'>Persistent data or "lab mode" is a feature of the Roborock S5x which allows to save no-go areas and virtual walls. It also allows the robot to drive back to the dock wherever it is and keeps the map from being rotated.</ons-col>
+                <ons-col width="500px">Persistent data is a feature of the Roborock S5x which allows it to save the current map. Zones, no-go areas and virtual walls are also saved. This solves issues with rotating maps and incorrect zone co-ordinates.
+                <br/><br/>
+                Important: Before saving - ensure that the map (or a portion of the map) already exists in the map view.
+                </ons-col>
                 <ons-col></ons-col>
             </ons-row>
 
             <ons-row id="persistent_data_not_supported" class="hidden">
                 <ons-col></ons-col>
-                <ons-col width="300px" vertical-align='center' style='text-align:center; max-width: 400px;'>
+                <ons-col width="500px" vertical-align='center' style='text-align:center; max-width: 400px;'>
                     <strong>Sorry .. only the RoboRock S5x supports the persistent map features.</strong>
                 </ons-col>
                 <ons-col></ons-col>
@@ -2004,19 +2007,9 @@
             <form id="persistent_data_form" class="hidden">
                 <ons-row>
                     <ons-col></ons-col>
-                    <ons-col width="150px" vertical-align='center'>Enabled</ons-col>
-                    <ons-col width="150px" vertical-align='center'><ons-checkbox input-id="lab_mode_enabled"></ons-checkbox></ons-col>
-                    <ons-col></ons-col>
-                </ons-row>
-                <ons-row>
-                    <ons-col><br/></ons-col>
-                </ons-row>
-                <ons-row>
-                    <ons-col></ons-col>
-                    <ons-col width="150px" vertical-align='center'>Delete persistent data</ons-col>
-                    <ons-col width="150px" vertical-align='center'>
-                        <ons-button id="reset_map_button" title="This deletes the current map, all no-go zones and virtual walls!" modifier="large" class="button-margin" onclick="document.getElementById('confirm_reset_map').show();">
-                            Reset Map
+                    <ons-col width="200px" vertical-align='center'>
+                        <ons-button modifier="cta" title="Saves the current map" modifier="large" class="button-margin" onclick="enablePersistentData(true);">
+                            Save Current Map
                         </ons-button>
                     </ons-col>
                     <ons-col></ons-col>
@@ -2026,7 +2019,11 @@
                 </ons-row>
                 <ons-row>
                     <ons-col></ons-col>
-                    <ons-col width="100px" vertical-align='center'><ons-button modifier="large" class="button-margin" onclick="savePersistentData();">Save</ons-button></ons-col>
+                    <ons-col width="200px" vertical-align='center'>
+                        <ons-button modifier="outline" title="This deletes the current map, all no-go zones and virtual walls!" modifier="large" class="button-margin" onclick="document.getElementById('confirm_reset_map').show();">
+                            Reset Current Map
+                        </ons-button>
+                    </ons-col>
                     <ons-col></ons-col>
                 </ons-row>
             </form>
@@ -2078,29 +2075,6 @@
                 var loadingBarSettingsPersistentData = document.getElementById('loading-bar-settings-persistent-data');
 
                 ons.getScriptPage().onShow = function () {
-                    document.getElementById('lab_mode_enabled').addEventListener("change", function(event) {
-                        disableResetMap(!event.target.checked)
-                    });
-
-                    updateSettingsPersistentDataPage();
-                };
-
-                function disableResetMap(flag) {
-                    const resetMapButton = document.getElementById("reset_map_button");
-                    if(flag) {
-                        resetMapButton.setAttribute("disabled", "true");
-                    } else {
-                        resetMapButton.removeAttribute("disabled");
-                    }
-                }
-
-                function initForm(currentStatus) {
-                    var persistentDataForm = document.getElementById('persistent_data_form');
-                    document.getElementById('lab_mode_enabled').checked = (currentStatus.lab_status === 1);
-                    disableResetMap(currentStatus.lab_status !== 1);
-                }
-
-                function updateSettingsPersistentDataPage() {
                     loadingBarSettingsPersistentData.setAttribute("indeterminate", "indeterminate");
                     fn.request("api/current_status", "GET", function (err, res) {
                         loadingBarSettingsPersistentData.removeAttribute("indeterminate");
@@ -2110,7 +2084,6 @@
                             const isS50 = res.model === "roborock.vacuum.s5";
                             if(isS50) {
                                 document.getElementById('persistent_data_form').classList.remove("hidden");
-                                initForm(res);
                             } else {
                                 document.getElementById('persistent_data_not_supported').classList.remove("hidden");
                             }
@@ -2125,21 +2098,19 @@
                         if (err) {
                             ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: 1500 });
                         } else {
-                            ons.notification.toast("Map resetted!", { buttonLabel: 'Dismiss', timeout: 1500 });
+                            ons.notification.toast("Map reset!", { buttonLabel: 'Dismiss', timeout: 1500 });
                         }
                     });
                 }
 
-                function savePersistentData() {
-                    const labStatus = true === document.getElementById('lab_mode_enabled').checked;
-
+                function enablePersistentData(enable) {
                     loadingBarSettingsPersistentData.setAttribute("indeterminate", "indeterminate");
-                    fn.requestWithPayload("api/set_lab_status", JSON.stringify({ lab_status: labStatus }), "PUT", function (err, res) {
+                    fn.requestWithPayload("api/persistent_data", JSON.stringify({ enabled: enable }), "PUT", function (err, res) {
                         loadingBarSettingsPersistentData.removeAttribute("indeterminate");
                         if (err) {
                             ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: 1500 });
                         } else {
-                            ons.notification.toast("Saved settings!", { buttonLabel: 'Dismiss', timeout: 1500 });
+                            ons.notification.toast("Persistent data is now " + (enable ? "enabled" : "disabled") + "!", { buttonLabel: 'Dismiss', timeout: 1500 });
                         }
                     });
                 }

--- a/lib/miio/Vacuum.js
+++ b/lib/miio/Vacuum.js
@@ -550,6 +550,14 @@ Vacuum.prototype.setLabStatus = function(flag, callback) {
 }
 
 /**
+ * Saves the current map
+ * @param {(err: Error, res: any) => {}} callback
+ */
+Vacuum.prototype.saveMap = function(callback) {
+    this.sendMessage("save_map", [], {}, callback);
+}
+
+/**
  * Resets all persistent data (map, nogo areas and virtual walls)
  * @param {(err: Error, res: any) => {}} callback
  */

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -412,17 +412,27 @@ const WebServer = function (options) {
         });
     });
 
-    this.app.put("/api/set_lab_status", function (req, res) {
-        if (req.body && req.body.lab_status !== undefined) {
-            self.vacuum.setLabStatus(req.body.lab_status, function (err, data) {
+    this.app.put("/api/persistent_data", function (req, res) {
+        if (req.body && req.body.enabled !== undefined) {
+            self.vacuum.setLabStatus(req.body.enabled, function (err, data) {
                 if (err) {
                     res.status(500).send(err.toString());
                 } else {
-                    res.json({message: "ok"});
+                    if (req.body.enabled) {
+                        self.vacuum.saveMap(function (err) {
+                            if (err) {
+                                res.status(500).send(err.toString());
+                            } else {
+                                res.json({message: "ok"});
+                            }
+                        })
+                    } else {
+                        res.json({message: "ok"});
+                    }
                 }
             })
         } else {
-            res.status(400).send("lab_status missing");
+            res.status(400).send("enabled missing");
         }
     });
 
@@ -839,7 +849,7 @@ const WebServer = function (options) {
         wss.clients.forEach(function each(ws) {
             //terminate inactive ws
             if (ws.isAlive === false) return ws.terminate();
- 			
+
             //mark ws as inactive
             ws.isAlive = false;
             //ask ws to send a pong to be marked as active


### PR DESCRIPTION
<img width="998" alt="Screenshot 2019-06-19 at 17 56 15" src="https://user-images.githubusercontent.com/1367878/59784975-95b94f00-92bb-11e9-9588-e28b7f6303f7.png">

Currently in `master` map saving is not working correctly, `set_lab_status` is not enough to enable map persistence and the UI could be confusing to users without knowledge of `mirobo` commands.

Following on from https://github.com/Hypfer/Valetudo/pull/247 — this PR simplifies the UI with two buttons:

* `Save Current Map` ->  Calls raw command `set_lab_status 1` + `save_map`.
* `Reset Current Map` ->  Calls raw command `reset_map`.

Note that calling `reset_map` is enough to disable map saving.

Tested extensively on an S55.