### PR TITLE
Valetudo version check

### DIFF
--- a/client/settings-info.html
+++ b/client/settings-info.html
@@ -27,14 +27,6 @@
                 ???
             </div>
         </ons-list-item>
-        <ons-list-item>
-            <div class="left">
-                Valetudo version:
-            </div>
-            <div class="right" id="info_valetudo_version">
-                ???
-            </div>
-        </ons-list-item>
     </ons-list>
     <ons-list-title style="margin-top:5px;">App Locale</ons-list-title>
     <ons-list>
@@ -87,6 +79,35 @@
             </div>
         </ons-list-item>
     </ons-list>
+    <ons-list-title style="margin-top:5px;">Valetudo</ons-list-title>
+    <ons-list>
+        <ons-list-item>
+            <div class="left">
+                Running Valetudo version:
+            </div>
+            <div class="right" id="info_valetudo_version">
+                ???
+            </div>
+        </ons-list-item>
+        <ons-list-item>
+            <div class="left">
+                Newest Valetudo version:
+            </div>
+            <div class="right" id="info_newest_valetudo_version">
+                <ons-button modifier="large" class="button-margin" onclick="checkNewValetudoVersion();">Check for new Valuto Version</ons-button>
+            </div>
+        </ons-list-item>
+        <ons-list-item id="info_valetudo_update_url_list" style="display: none;">
+            <div class="left">
+                Newest Version URL:
+            </div>
+            <div class="right" id="info_valetudo_update_url">
+                ???
+            </div>
+        </ons-list-item>
+    </ons-list>
+
+
 
 
     <script>
@@ -122,6 +143,28 @@
                     document.getElementById('app_locale_logserver').innerHTML = appLocale.logserver;
                 } else {
                     ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: 1500 })
+                }
+            });
+        }
+
+        function checkNewValetudoVersion() {
+            loadingBarSettingsInfo.setAttribute("indeterminate", "indeterminate");
+            fn.request("https://api.github.com/repos/Hypfer/Valetudo/releases", "GET", function (err, res) {
+                loadingBarSettingsInfo.removeAttribute("indeterminate");
+                if (!err) {
+                    try {
+                        var info_valetudo_newest_release = res[0];
+                        document.getElementById('info_newest_valetudo_version').innerHTML = info_valetudo_newest_release.tag_name;
+                        document.getElementById('info_valetudo_update_url').innerHTML = '<a href="'+info_valetudo_newest_release.html_url+'">'+info_valetudo_newest_release.html_url+'</a>';
+                        if( document.getElementById('info_valetudo_version').innerHTML != info_valetudo_newest_release.tag_name)
+                        {
+                                document.getElementById('info_valetudo_update_url_list').style.display = ""; //make entry visible if newer version is availiable
+                        }
+                    } catch (e) {
+                        ons.notification.toast(e, { buttonLabel: 'Dismiss', timeout: 1500 });
+                    }
+                } else {
+                    ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: 1500 });
                 }
             });
         }


### PR DESCRIPTION
Adds a button to manually trigger a check for the newest valetudo version (on github).
See  #146 