### PR TITLE
Dockerfile for building Valetudo

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:14.04
+
+# Build:
+# docker build -t valetudo-compiler .
+
+# Copy binary to current directory:
+# docker run --rm -it -v $(pwd):/host valetudo-compiler bash -c "cp /Valetudo/valetudo /host && chown $(id -u):$(id -g) /host/valetudo"
+
+RUN apt-get update \
+; apt-get -y --force-yes install wget git nodejs npm nodejs-legacy \
+; npm config set strict-ssl false \
+; npm install -g n \
+; n latest \
+; git clone http://github.com/hypfer/Valetudo \
+; cd Valetudo \
+; /usr/local/bin/npm install \
+; /usr/local/bin/npm run build \


### PR DESCRIPTION
As requested in #266, here's a simple Dockerfile which will build Valetudo and drop a binary in the current directory by running the following command: 
`docker run --rm -it -v $(pwd):/host valetudo-compiler bash -c "cp /Valetudo/valetudo /host && chown $(id -u):$(id -g) /host/valetudo"`