### PR TITLE
make basic auth dynamically switchable on/off

### DIFF
--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -54,25 +54,32 @@ const WebServer = function (options) {
         }
     });
 
+    const basicAuthUnauthorizedResponse = function(req) {
+        return req.auth ? ('Credentials "' + req.auth.user + ':' + req.auth.password + '" rejected') : 'No credentials provided';
+    }
+
     const basicAuthMiddleware = basicAuth({authorizer: function(username, password) {
         const userMatches = basicAuth.safeCompare(username, self.configuration.get("httpAuth").username);
         const passwordMatches = basicAuth.safeCompare(password, self.configuration.get("httpAuth").password);
-
         return userMatches & passwordMatches;
-    }, challenge: true});
+    }, challenge: true, unauthorizedResponse: basicAuthUnauthorizedResponse});
 
-    const authMiddleware = dynamicMiddleware.create(function(req, res, next) {
+    const authMiddleware = function(req, res, next) {
         if (['127.0.0.1', '::1', '::ffff:127.0.0.1'].includes(req.ip)) {
             // Allow requests from localhost
             next();
         } else {
             // Authenticate other ones
-            basicAuthMiddleware(req, res, next);
+            try {
+                basicAuthMiddleware(req, res, next);
+            } catch (e) { /* basicAuth throws [ERR_HTTP_HEADERS_SENT] here if invalid credentials are sent */ }
         }
-    });
+    };
+    const dynamicAuth = dynamicMiddleware.create([]);
+    this.app.use(dynamicAuth.handle());
 
     if (this.configuration.get("httpAuth").enabled) {
-        this.app.use(authMiddleware.handle());
+        dynamicAuth.use(authMiddleware);
         this.basicAuthInUse = true;
     }
 
@@ -515,10 +522,10 @@ const WebServer = function (options) {
                 password: pass,
             });
             if (self.basicAuthInUse && !req.body.enabled) {
-                authMiddleware.unuse();
+                dynamicAuth.unuse(authMiddleware);
                 self.basicAuthInUse = false;
             } else if (!self.basicAuthInUse && req.body.enabled) {
-                self.app.use(authMiddleware.handle());
+                dynamicAuth.use(authMiddleware);
                 self.basicAuthInUse = true;
             }
             res.status(201).json({message: "ok"});


### PR DESCRIPTION
currently it's required to restart valetudo process after enabling or disabling basic auth in settings for changes to take effect. this PR fixes the issue making switching that setting really dynamic