### PR TITLE
Make mqttConfig.provideMapdata not always true.

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -78,7 +78,7 @@ const MqttClient = function (options) {
     this.topicPrefix = mqttConfig.topicPrefix || "valetudo";
     this.autoconfPrefix = mqttConfig.autoconfPrefix || "homeassistant";
     this.attributesUpdateInterval = mqttConfig.attributesUpdateInterval || 60000;
-    this.provideMapData = mqttConfig.provideMapData !== undefined || true;
+    this.provideMapData = mqttConfig.provideMapData ? mqttConfig.provideMapData : true;
     this.caPath = mqttConfig.caPath || "";
     this.events = options.events;
     this.map = options.map;


### PR DESCRIPTION
The way it was set before would always evaluate to true.