### PR TITLE
Fixed API URL to a relative path

### DIFF
--- a/client/settings-timers.html
+++ b/client/settings-timers.html
@@ -234,7 +234,7 @@
             ons.notification.confirm('Do you really want to set your timezone to "' + newTimezone + '"?').then(function (answer) {
                 if (answer === 1) {
                     loadingBarSettingsTimers.setAttribute("indeterminate", "indeterminate");
-                    fn.requestWithPayload("/api/set_timezone", JSON.stringify({ new_zone : newTimezone }), "POST", function (err, res) {
+                    fn.requestWithPayload("api/set_timezone", JSON.stringify({ new_zone : newTimezone }), "POST", function (err, res) {
                         loadingBarSettingsTimers.removeAttribute("indeterminate");
                         if (err) {
                             ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: window.fn.toastErrorTimeout });
@@ -331,7 +331,7 @@
             var end_hour = document.getElementById('edit-dnd-form').end_hour.value;
             var end_minute = document.getElementById('edit-dnd-form').end_minute.value;
             if (start_hour && start_minute && end_hour && end_minute) {
-                fn.requestWithPayload("/api/set_dnd", JSON.stringify({ start_hour, start_minute, end_hour, end_minute}), "POST", function (err, res) {
+                fn.requestWithPayload("api/set_dnd", JSON.stringify({ start_hour, start_minute, end_hour, end_minute}), "POST", function (err, res) {
                 if (err) {
                     ons.notification.toast(err, { buttonLabel: 'Dismiss', timeout: window.fn.toastErrorTimeout });
                 }


### PR DESCRIPTION
Most endpoints work fine when the app is hosted under a path that isn't `/` because they use relative URLs, but these two were missing.