### PR TITLE
Fix #289 Instantly update no-go zones and virtual walls

### DIFF
--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -550,6 +550,8 @@ const WebServer = function (options) {
                     if(err) {
                         res.status(500).json(err);
                     } else {
+                        self.map.parsedData.virtual_walls = req.body.virtual_walls;
+                        self.map.parsedData.no_go_areas = req.body.no_go_areas;    
                         res.status(201).json({message: "ok"});
                     }
                 });


### PR DESCRIPTION
This PR fixes #289.

The issue was caused because the no-go zones and virtual walls are stored in xiaomis map data. Valetudo caches the map data in the `self.map.parsedData` variable in WebServer.js.
This variable only gets updated when the robot uploads a new map to the dummy cloud.

Valetudo calls the `/api/map/latest` endpoint before opening the editor window to get the latest no-go zones and virtual walls. The information returned by this endpoint might not be up-to-date when the no-go zones where changed after the last map upload.

To fix this we just needed to update the `self.map.parsedData` variable in the `/api/persistent_data` endpoint with the data send by the frontend (used to update no-go zones and virtual walls). This will make sure that the changes are visible even before the robot has uploaded a new map.