### PR TITLE
feat(docker): switch to yarn and latest node lts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM node:8.12.0-alpine
+FROM node:lts-alpine
 
 WORKDIR /
 COPY . .
 
-RUN npm install --quiet
+RUN yarn install --frozen-lockfile --silent
 
-ENTRYPOINT [ "npm", "run-script", "build" ]
+ENTRYPOINT [ "yarn", "build" ]


### PR DESCRIPTION
Hi there, thanks for your nice project. I am using it every week.

I updated the Dockerfile to the latest `node:lts-alpine` since it was getting a little outdated.

I also switched to yarn for the docker install. You have a `yarn.lock` in the project already, but the Docker build was not using it since it it executed the script with `npm`.

The `--frozen-lockfile` option is also good practice to prevent the Docker build from running different dependencies from what is actually in your `package.json` (https://yarnpkg.com/lang/en/docs/cli/install/#toc-yarn-install-frozen-lockfile)

