### PR TITLE
Send MQTT attributes only if they changed

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -124,6 +124,7 @@ const MqttClient = function (options) {
         id: -1,
         name: Vacuum.GET_STATE_CODE_DESCRIPTION(-1)
     };
+    this.last_attributes = {};
 
 
     this.connect();
@@ -261,8 +262,10 @@ MqttClient.prototype.updateAttributesTopic = function () {
                             response.zoneStatus = zoneCleaningStatus
                         }
 
-
-                        this.client.publish(this.topics.attributes, JSON.stringify(response), {retain: true, qos:this.qos});
+                        if (JSON.stringify(response) !== JSON.stringify(this.last_attributes)) {
+                            this.client.publish(this.topics.attributes, JSON.stringify(response), {retain: true, qos:this.qos});
+                            this.last_attributes = response;
+                        }
 
                         this.attributesUpdateTimeout = setTimeout(() => {
                             this.updateAttributesTopic()


### PR DESCRIPTION
Current behavior is to send attributes every 60s even they not changed. It's not necessary as messages sent with retain flag.