### PR TITLE
adds proper shutdown on SIGTERM and SIGINT

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,27 @@
 const Valetudo = require("./lib/Valetudo");
-new Valetudo();
+const process = require("process");
+
+var valetudo = new Valetudo();
+
+function shutdown() {
+    try {
+        valetudo.shutdown();
+    } catch (err) {
+        console.error("Error occured: ",  err.name, " - ",err.message);
+        console.error(err.stack);
+    }
+    // need to exit here because otherwise the process would stay open
+    process.exit(0);
+}
+
+// Signal termination handler - used if the process is killed
+// (e.g. kill command, service valetudo stop, reboot (via upstart),...)
+process.on('SIGTERM', shutdown);
+
+// Signal interrupt handler - 
+// e.g. if the process is aborted by Ctrl + C (during dev)
+process.on('SIGINT', shutdown);
+
+process.on('exit', function() {
+    console.info("exiting...")
+});

--- a/index.js
+++ b/index.js
@@ -5,13 +5,15 @@ var valetudo = new Valetudo();
 
 function shutdown() {
     try {
-        valetudo.shutdown();
+        valetudo.shutdown(() => {
+            // need to exit here because otherwise the process would stay open
+            process.exit(0);
+        })
     } catch (err) {
         console.error("Error occured: ",  err.name, " - ",err.message);
         console.error(err.stack);
+        process.exit(1);
     }
-    // need to exit here because otherwise the process would stay open
-    process.exit(0);
 }
 
 // Signal termination handler - used if the process is killed

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -416,13 +416,12 @@ MqttClient.prototype.handleCustomCommand = function (message) {
     }
 };
 
-MqttClient.prototype.shutdown = function() {
-    console.debug("Shutting down the MQTT Client...")
-    
-    //force close the mqtt client
-    this.client.end(true);
-
-    console.debug("Shutting down the MQTT Client done.")
+MqttClient.prototype.shutdown = function(callback) {
+    console.debug("Shutting down the MQTT Client...");
+    this.client.end(true, () => {
+        console.debug("Shutting down the MQTT Client done");
+        callback();
+    });
 }
 
 module.exports = MqttClient;

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -416,4 +416,13 @@ MqttClient.prototype.handleCustomCommand = function (message) {
     }
 };
 
+MqttClient.prototype.shutdown = function() {
+    console.debug("Shutting down the MQTT Client...")
+    
+    //force close the mqtt client
+    this.client.end(true);
+
+    console.debug("Shutting down the MQTT Client done.")
+}
+
 module.exports = MqttClient;

--- a/lib/Valetudo.js
+++ b/lib/Valetudo.js
@@ -58,6 +58,7 @@ const Valetudo = function() {
 
 
     if(this.configuration.get("mqtt") && this.configuration.get("mqtt").enabled === true) {
+        console.log("mqtt start");
         this.mqttClient = new MqttClient({
             configuration: this.configuration,
             vacuum: this.vacuum,
@@ -132,24 +133,39 @@ Valetudo.VACUUM_MODEL_PROVIDER = function() {
     }
 };
 
-Valetudo.prototype.shutdown = function() {
+Valetudo.prototype.shutdown = function(callback) {
     console.info("Valetudo shutdown in progress...")
-    
-    //shutdwon mqtt client
-    if(this.configuration.get("mqtt") && this.configuration.get("mqtt").enabled === true) {
-        this.mqttClient.shutdown();
+
+    // to ensure that the correct context is used within inner/anonymous functions
+    var self = this;
+
+    // sets the mqtt shutdown method
+    // this is required because the mqttClient is not always initialized (dependent on the config)
+    var mqttShutdown;
+    if(self.mqttClient) {
+        mqttShutdown = self.mqttClient.shutdown;
+    } else {
+        mqttShutdown = function(callback) {
+            callback();
+        }
     }
 
-    //shutdown webserver
-    this.webserver.shutdown();
-    
-    //shutdown vacuum
-    this.vacuum.shutdown();
-    
-    //shutdown dummycloud
-    this.dummycloud.shutdown();
-
-    console.info("Valetudo shutdown done.")
+    // callback hell!
+    // shuts down valetudo in the following sequence (reverse startup sequence):
+    // 1) mqtt
+    // 2) webserver
+    // 3) vacuum
+    // 4) dummycloud
+    mqttShutdown.bind(self.mqttClient)(() => {
+        self.webserver.shutdown.bind(self.webserver)(() => {
+            self.vacuum.shutdown.bind(self.vacuum)(() => {
+                self.dummycloud.shutdown.bind(self.dummycloud)(() => {
+                    console.info("Valetudo shutdown done")
+                    callback();
+                });
+            });
+        });
+    });
 }
 
 module.exports = Valetudo;

--- a/lib/Valetudo.js
+++ b/lib/Valetudo.js
@@ -132,4 +132,24 @@ Valetudo.VACUUM_MODEL_PROVIDER = function() {
     }
 };
 
+Valetudo.prototype.shutdown = function() {
+    console.info("Valetudo shutdown in progress...")
+    
+    //shutdwon mqtt client
+    if(this.configuration.get("mqtt") && this.configuration.get("mqtt").enabled === true) {
+        this.mqttClient.shutdown();
+    }
+
+    //shutdown webserver
+    this.webserver.shutdown();
+    
+    //shutdown vacuum
+    this.vacuum.shutdown();
+    
+    //shutdown dummycloud
+    this.dummycloud.shutdown();
+
+    console.info("Valetudo shutdown done.")
+}
+
 module.exports = Valetudo;

--- a/lib/miio/Dummycloud.js
+++ b/lib/miio/Dummycloud.js
@@ -249,4 +249,17 @@ Dummycloud.SERVER_REQUESTS = {
     "STATUS": -2
 };
 
+Dummycloud.prototype.shutdown = function() {
+    console.debug("Dummycloud shutdown in progress...");
+
+    try {
+        this.socket.disconnect();
+    } catch(err) {
+        // do nothing, no connection is open
+    }
+    this.socket.close();
+
+    console.debug("Dummycloud shutdown done");
+}
+
 module.exports = Dummycloud;

--- a/lib/miio/Dummycloud.js
+++ b/lib/miio/Dummycloud.js
@@ -249,7 +249,7 @@ Dummycloud.SERVER_REQUESTS = {
     "STATUS": -2
 };
 
-Dummycloud.prototype.shutdown = function() {
+Dummycloud.prototype.shutdown = function(callback) {
     console.debug("Dummycloud shutdown in progress...");
 
     try {
@@ -257,9 +257,10 @@ Dummycloud.prototype.shutdown = function() {
     } catch(err) {
         // do nothing, no connection is open
     }
-    this.socket.close();
-
-    console.debug("Dummycloud shutdown done");
+    this.socket.close(() => {
+        console.debug("Dummycloud shutdown done");
+        callback();
+    });
 }
 
 module.exports = Dummycloud;

--- a/lib/miio/Vacuum.js
+++ b/lib/miio/Vacuum.js
@@ -791,7 +791,7 @@ Vacuum.ERROR_CODES = {
     19: "Unpowered charging station",
 };
 
-Vacuum.prototype.shutdown = function() {
+Vacuum.prototype.shutdown = function(callback) {
     console.debug("Vacuum shutdown in progress...");
 
     try {
@@ -799,9 +799,10 @@ Vacuum.prototype.shutdown = function() {
     } catch(err) {
         // do nothing, no connection is open
     }
-    this.socket.close();
-
-    console.debug("Vacuum shutdown done");
+    this.socket.close(() => {
+        console.debug("Vacuum shutdown done");
+        callback();
+    });
 }
 
 module.exports = Vacuum;

--- a/lib/miio/Vacuum.js
+++ b/lib/miio/Vacuum.js
@@ -791,4 +791,17 @@ Vacuum.ERROR_CODES = {
     19: "Unpowered charging station",
 };
 
+Vacuum.prototype.shutdown = function() {
+    console.debug("Vacuum shutdown in progress...");
+
+    try {
+        this.socket.disconnect();
+    } catch(err) {
+        // do nothing, no connection is open
+    }
+    this.socket.close();
+
+    console.debug("Vacuum shutdown done");
+}
+
 module.exports = Vacuum;

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -951,13 +951,14 @@ const WebServer = function (options) {
 WebServer.WIFI_CONNECTED_IW_REGEX = /^Connected to ([0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2})(?:.*\s*)SSID: (.*)\s*freq: ([0-9]*)\s*signal: ([-]?[0-9]* dBm)\s*tx bitrate: ([0-9.]* .*)/;
 WebServer.OS_RELEASE_FW_REGEX = /^NAME=(.*)\nVERSION=(.*)\nID=(.*)\nID_LIKE=(.*)\nPRETTY_NAME=(.*)\nVERSION_ID=(.*)\nHOME_URL=(.*)\nSUPPORT_URL=(.*)\nBUG_REPORT_URL=(.*)\n(ROCKROBO|ROBOROCK)_VERSION=(.*)/;
 
-WebServer.prototype.shutdown = function() {
+WebServer.prototype.shutdown = function(callback) {
     console.debug("Webserver shutdown in progress...");
 
     //closing the server
-    this.webserver.close();
-
-    console.debug("Webserver shutdown done");
+    this.webserver.close(() => {
+        console.debug("Webserver shutdown done");
+        callback();
+    });
 }
 
 module.exports = WebServer;

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -944,10 +944,20 @@ const WebServer = function (options) {
     server.listen(this.port, function () {
         console.log("Webserver running on port", self.port)
     });
+    this.webserver = server;
 };
 
 //This is the sole reason why I've bought a 21:9 monitor
 WebServer.WIFI_CONNECTED_IW_REGEX = /^Connected to ([0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2}:[0-9a-f]{2})(?:.*\s*)SSID: (.*)\s*freq: ([0-9]*)\s*signal: ([-]?[0-9]* dBm)\s*tx bitrate: ([0-9.]* .*)/;
 WebServer.OS_RELEASE_FW_REGEX = /^NAME=(.*)\nVERSION=(.*)\nID=(.*)\nID_LIKE=(.*)\nPRETTY_NAME=(.*)\nVERSION_ID=(.*)\nHOME_URL=(.*)\nSUPPORT_URL=(.*)\nBUG_REPORT_URL=(.*)\n(ROCKROBO|ROBOROCK)_VERSION=(.*)/;
+
+WebServer.prototype.shutdown = function() {
+    console.debug("Webserver shutdown in progress...");
+
+    //closing the server
+    this.webserver.close();
+
+    console.debug("Webserver shutdown done");
+}
 
 module.exports = WebServer;


### PR DESCRIPTION
Shutdown handler on unix signals:
- SIGTERM
- SIGINT

closes all open sockets, clients and shuts down the webserver before valetudo is closed.

Resource cleanup and closing open file descriptors (sockets, files,...) is always a good idea when shutting down an application (sometimes file systems can get corrupt when they could not be unmounted correctly during os shutdown due to  e.g. open file descriptors) . So this change might help with the reset issue but I'm not really sure about that.


Please review especially the listed points, as I'm petty new to the code base and node/javascript in general:
- I think all used calls for closing resources are synchronous calls. If not we/I need to refactor the synchronous shutdown methods to asynchronous methods.
- In some classes files are opened for read/write (e.g. Configuration.js). As far as I understand the docs these calls close the opened files automatically?
- Webserver.js:947: had to add this as a workaround (it seems that the variable 'server' needs to be const as it us used later on in a callback) to get to the webserver instance. Maybe someone has a better idea?