### PR TITLE
Add unique_id for MQTT Discovery

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -97,6 +97,7 @@ const MqttClient = function (options) {
     this.autoconf_payloads = {
         vacuum: {
             name: this.identifier,
+            unique_id: this.identifier,
             schema: "state",
             supported_features: [
                 "start",


### PR DESCRIPTION
See https://www.home-assistant.io/docs/mqtt/discovery/ and https://github.com/home-assistant/home-assistant/pull/20503
Without unique_id MQTT Discovery isn't working with actual versions of Home Assistant