### PR TITLE
remove unnecessary loop

### DIFF
--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -880,32 +880,26 @@ const WebServer = function (options) {
     self.events.on("valetudo.map", () => {
         const mapJSON = JSON.stringify(self.map.parsedData);
 
-        //Too many connected clients might cause valetudo to go OOM
-        //If this is the case, we should limit the amount of concurrent responses
-        //However for now, it should be sufficient to just limit the concurrent responses per client to one
-        wss.clients.forEach(function each(ws) {
-            // don't need to compress anything if all clients are still in progress
-            if (!Array.from(wss.clients).some(ws => !ws.mapUploadInProgress)) {
-                return;
-            }
-            // zlib compression on map.parsedData allows to send up to 5x times less data via the network
-            zlib.deflate(JSON.stringify(self.map.parsedData), (err, buf) => {
-                //Too many connected clients might cause valetudo to go OOM
-                //If this is the case, we should limit the amount of concurrent responses
-                //However for now, it should be sufficient to just limit the concurrent responses per client to one
-                if (!err)
-                    wss.clients.forEach(function each(ws) {
-                        if (!ws.mapUploadInProgress) {
-                            ws.mapUploadInProgress = true;
+        // don't need to compress anything if all clients are still in progress
+        if (!Array.from(wss.clients).some(ws => !ws.mapUploadInProgress)) {
+            return;
+        }
+        // zlib compression on map.parsedData allows to send up to 5x times less data via the network
+        zlib.deflate(JSON.stringify(self.map.parsedData), (err, buf) => {
+            //Too many connected clients might cause valetudo to go OOM
+            //If this is the case, we should limit the amount of concurrent responses
+            //However for now, it should be sufficient to just limit the concurrent responses per client to one
+            if (!err)
+                wss.clients.forEach(function each(ws) {
+                    if (!ws.mapUploadInProgress) {
+                        ws.mapUploadInProgress = true;
 
-                            ws.send(buf, function () {
-                                ws.mapUploadInProgress = false;
-                            });
-                        }
-                    });
-            });
+                        ws.send(buf, function () {
+                            ws.mapUploadInProgress = false;
+                        });
+                    }
+                });
         });
-
     });
 
     setInterval(function () {


### PR DESCRIPTION
That outer loop caused one zlib compression per client and client² ws.sends.
One compression and one send per client is enough...

