### PR TITLE
[Viomi] Support robot-provided zones.

### DIFF
--- a/client/zones-configuration-map.html
+++ b/client/zones-configuration-map.html
@@ -38,6 +38,7 @@
         s.src = "zones-configuration-map.js";
         s.type = "module";
         ons.getScriptPage().appendChild(s);
+        s.onreadystatechange = s.onload = () => { window.zoneMapInit(); };
       }
     </script>
     <style>

--- a/client/zones-configuration-map.js
+++ b/client/zones-configuration-map.js
@@ -8,13 +8,14 @@ const renameDialog = document.getElementById("rename-zone-dialog");
 const renameZoneInput = document.getElementById("rename-zone-input");
 
 const topPage = fn.getTopPage();
+/** @type {Array<{id:number, name:string, user: boolean, areas: Array}>} */
 const zonesConfig = topPage.data.zonesConfig;
 const zoneToModify = topPage.data.zoneToModify;
 
 map.initCanvas(topPage.data.map, {metaData: "forbidden", noGotoPoints: true});
 
 updateZoneName();
-for (let zone of zonesConfig[zoneToModify].coordinates) {
+for (let zone of zonesConfig[zoneToModify].areas) {
     map.addZone([zone[0], zone[1], zone[2], zone[3]], true);
 }
 
@@ -34,9 +35,8 @@ renameButton.onclick =
         };
 
 function saveZone(hide) {
-    const zonesOnMap =
-                      map.getLocations().zones.map(zoneCoordinates => [...zoneCoordinates, 1]);
-    zonesConfig[zoneToModify].coordinates = zonesOnMap;
+    const areasOnMap = map.getLocations().zones.map(zoneCoordinates => [...zoneCoordinates, 1]);
+    zonesConfig[zoneToModify].areas = areasOnMap;
 
     loadingBarSaveZones.setAttribute("indeterminate", "indeterminate");
     saveButton.setAttribute("disabled", "disabled");

--- a/client/zones-configuration-map.js
+++ b/client/zones-configuration-map.js
@@ -1,38 +1,49 @@
 /*global ons, fn*/
 import {VacuumMap} from "./zone/js-modules/vacuum-map.js";
-const map = new VacuumMap(document.getElementById("zone-configuration-map"));
-const loadingBarSaveZones = document.getElementById("loading-bar-save-zones");
-const saveButton = document.getElementById("zones-configuration-save");
-const renameButton = document.getElementById("zones-configuration-rename");
-const renameDialog = document.getElementById("rename-zone-dialog");
-const renameZoneInput = document.getElementById("rename-zone-input");
 
-const topPage = fn.getTopPage();
+let map;
+let loadingBarSaveZones;
+let saveButton;
+let renameButton;
+let renameDialog;
+let renameZoneInput;
+
+let topPage;
 /** @type {Array<{id:number, name:string, user: boolean, areas: Array}>} */
-const zonesConfig = topPage.data.zonesConfig;
-const zoneToModify = topPage.data.zoneToModify;
+let zonesConfig;
+let zoneToModify;
 
-map.initCanvas(topPage.data.map, {metaData: "forbidden", noGotoPoints: true});
+function zoneMapInit() {
+    map = new VacuumMap(document.getElementById("zone-configuration-map"));
+    loadingBarSaveZones = document.getElementById("loading-bar-save-zones");
+    saveButton = document.getElementById("zones-configuration-save");
+    renameButton = document.getElementById("zones-configuration-rename");
+    renameDialog = document.getElementById("rename-zone-dialog");
+    renameZoneInput = document.getElementById("rename-zone-input");
 
-updateZoneName();
-for (let zone of zonesConfig[zoneToModify].areas) {
-    map.addZone([zone[0], zone[1], zone[2], zone[3]], true);
-}
+    topPage = fn.getTopPage();
+    zonesConfig = topPage.data.zonesConfig;
+    zoneToModify = topPage.data.zoneToModify;
+    map.initCanvas(topPage.data.map, {metaData: "forbidden", noGotoPoints: true});
 
-document.getElementById("zones-configuration-add-zone").onclick = () => {
-    map.addZone();
-};
+    updateZoneName();
+    for (let zone of zonesConfig[zoneToModify].areas) {
+        map.addZone([zone[0], zone[1], zone[2], zone[3]], true);
+    }
 
-saveButton.onclick =
-    () => {
+    document.getElementById("zones-configuration-add-zone").onclick = () => {
+        map.addZone();
+    };
+
+    saveButton.onclick = () => {
         saveZone(true);
     };
 
-renameButton.onclick =
-        () => {
-            renameZoneInput.value = zonesConfig[zoneToModify].name;
-            renameDialog.show();
-        };
+    renameButton.onclick = () => {
+        renameZoneInput.value = zonesConfig[zoneToModify].name;
+        renameDialog.show();
+    };
+}
 
 function saveZone(hide) {
     const areasOnMap = map.getLocations().zones.map(zoneCoordinates => [...zoneCoordinates, 1]);
@@ -85,3 +96,4 @@ renameZone() {
 
 window.hideRenameZoneDialog = hideRenameZoneDialog;
 window.renameZone = renameZone;
+window.zoneMapInit = zoneMapInit;

--- a/client/zones.js
+++ b/client/zones.js
@@ -2,6 +2,8 @@
 let loadingBarZones = document.getElementById("loading-bar-zones");
 let zonesList = document.getElementById("zones-list");
 let spotList = document.getElementById("spot-list");
+
+/** @type {Array<{id:number, name:string, user: boolean, areas: Array}>} */
 let zonesConfig = [];
 let spotConfig = [];
 
@@ -62,7 +64,6 @@ function switchToForbiddenMarkersEdit(index) {
 // eslint-disable-next-line no-unused-vars
 function deleteZone(index) {
     zonesConfig.splice(index, 1);
-
     saveZones();
 }
 
@@ -109,7 +110,8 @@ function addNewZone() {
         ons.notification.toast("Please enter a zone name",
             {buttonLabel: "Dismiss", timeout: window.fn.toastErrorTimeout});
     } else {
-        zonesConfig.push({name: newZoneName, coordinates: []});
+        const id = Math.min(...zonesConfig.map(v => v.id)) - 1;
+        zonesConfig.push({id, name: newZoneName, areas: [], user: true});
     }
 
     saveZones();
@@ -132,6 +134,7 @@ function addNewSpot() {
 function generateZonesList() {
     let out = "";
     zonesConfig.forEach((zone, index) => {
+        if (!zone.user) return;
         out += `
                     <ons-list-item tappable class="locations-list-item" onclick="switchToMapZoneEdit(${
     index})">

--- a/develop/config.json.example
+++ b/develop/config.json.example
@@ -1,2 +1,2 @@
-{"spots":[],"areas":[]}
+{"spots":[],"zones":[]}
 

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -22,20 +22,10 @@ class Configuration {
             Logger.info("Loading configuration file:", this.location);
 
             try {
-                this.settings = Object.assign(this.settings, JSON.parse(fs.readFileSync(this.location, {"encoding": "utf-8"})));
-                // Migrate legacy "areas" to "zones"
-                if (this.settings["zones"] === undefined && this.settings["areas"] !== undefined) {
-                    /** @type {Array<Configuration.Zone>} */
-                    const zones = this.settings["areas"].map(
-                        (v, i) => ({
-                            id: -(i + 1),
-                            name: v[0],
-                            areas: v[1] ? Array.isArray(v[1]) ? v[1] : [v[1]] : [],
-                            user: true
-                        }));
-                    this.setZones(new Map(zones.map(v => [v.id, v])));
-                    delete this.settings["areas"];
-                }
+                this.settings = Object.assign(
+                    this.settings,
+                    JSON.parse(fs.readFileSync(this.location, {"encoding": "utf-8"})));
+                this.adoptLegacyAreas();
                 this.persist();
             } catch (e) {
                 Logger.error("Invalid configuration file!");
@@ -84,6 +74,24 @@ class Configuration {
 
     persist() {
         fs.writeFileSync(this.location, JSON.stringify(this.settings, null, 2));
+    }
+
+    /**
+     * Migrate legacy "areas" to "zones". Added in 2020-03, probably reasonable to remove by 2022.
+     */
+    adoptLegacyAreas() {
+        if (this.settings["zones"] === undefined && this.settings["areas"] !== undefined) {
+            /** @type {Array<Configuration.Zone>} */
+            const zones = this.settings["areas"].map(
+                (v, i) => ({
+                    id: -(i + 1),
+                    name: v[0],
+                    areas: v[1] ? Array.isArray(v[1]) ? v[1] : [v[1]] : [],
+                    user: true
+                }));
+            this.setZones(new Map(zones.map(v => [v.id, v])));
+            delete this.settings["areas"];
+        }
     }
 }
 

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -23,6 +23,19 @@ class Configuration {
 
             try {
                 this.settings = Object.assign(this.settings, JSON.parse(fs.readFileSync(this.location, {"encoding": "utf-8"})));
+                // Migrate legacy "areas" to "zones"
+                if (this.settings["zones"] === undefined && this.settings["areas"] !== undefined) {
+                    /** @type {Array<Configuration.Zone>} */
+                    const zones = this.settings["areas"].map(
+                        (v, i) => ({
+                            id: -(i + 1),
+                            name: v[0],
+                            areas: v[1] ? Array.isArray(v[1]) ? v[1] : [v[1]] : [],
+                            user: true
+                        }));
+                    this.setZones(new Map(zones.map(v => [v.id, v])));
+                    delete this.settings["areas"];
+                }
                 this.persist();
             } catch (e) {
                 Logger.error("Invalid configuration file!");
@@ -35,6 +48,16 @@ class Configuration {
             Tools.MK_DIR_PATH(path.dirname(this.location));
             this.persist();
         }
+    }
+
+    /** @returns {Map<number, Configuration.Zone>} */
+    getZones() {
+        return new Map(this.get("zones"));
+    }
+
+    /** @param {Map<number, Configuration.Zone>} zones */
+    setZones(zones) {
+        this.set("zones", [...zones]);
     }
 
     /**
@@ -63,5 +86,18 @@ class Configuration {
         fs.writeFileSync(this.location, JSON.stringify(this.settings, null, 2));
     }
 }
+
+/** @typedef {Array<number>} Configuration.Area */
+
+/**
+ * @typedef {{
+ *      id: number,
+ *      name: string,
+ *      areas?: Array<Configuration.Area>,
+ *      user: boolean
+ * }} Configuration.Zone
+ * Negative IDs are used for user-defined zones, which also have the user=true attribute set.
+ * Those cannot be edited by the UI.
+ */
 
 module.exports = Configuration;

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -381,17 +381,23 @@ class MqttClient {
                  *     "Baz"
                  *   ]
                  * }
+                 * Note: that zone_ids can be a mix of Zone IDs (numbers) and zone names.
                  */
-                case CUSTOM_COMMANDS.ZONED_CLEANUP:
-                    if (Array.isArray(msg.zone_ids) && msg.zone_ids.length) {
-                        this.vacuum.startCleaningZonesById(msg.zone_ids)
-                            .catch(err => {
-                                Logger.error(err);
-                            });
+                case CUSTOM_COMMANDS.ZONED_CLEANUP: {
+                    const zones = msg["zone_ids"];
+                    if (Array.isArray(zones) && zones.length) {
+                        const zone_ids = [...this.configuration.getZones().values()]
+                            .filter(zone => zones.includes(zone.name) ||
+                                            zones.includes(zone.id))
+                            .map(zone => zone.id);
+                        this.vacuum.startCleaningZonesById(zone_ids).catch(err => {
+                            Logger.error(err);
+                        });
                     } else {
                         Logger.info("Missing zone_ids or empty array");
                     }
                     break;
+                }
                 /**
                  * {
                  *   "command": "go_to",

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -384,7 +384,7 @@ class MqttClient {
                  */
                 case CUSTOM_COMMANDS.ZONED_CLEANUP:
                     if (Array.isArray(msg.zone_ids) && msg.zone_ids.length) {
-                        this.vacuum.startCleaningZoneByName(msg.zone_ids)
+                        this.vacuum.startCleaningZonesById(msg.zone_ids)
                             .catch(err => {
                                 Logger.error(err);
                             });

--- a/lib/ViomiMapParser.js
+++ b/lib/ViomiMapParser.js
@@ -58,9 +58,24 @@ ViomiMapParser.convertFloat = function(x) {
     return Math.ceil((20 + x) * 1000);
 };
 
+/**
+ * Converts a Valetudo location (mm shifted by 20m, upside-down) to Viomi position.
+ */
+ViomiMapParser.positionToViomi = function(x, y) {
+    y = ViomiMapParser.MAX_MAP_HEIGHT - y;
+    return {x: x / 1000 - 20, y: y / 1000 - 20};
+};
+
 /** Converts a viomi location 1/20m relative to 20m to Valetudo format. */
 ViomiMapParser.convertInt16 = function(x) {
     return x * 50;
+};
+
+ViomiMapParser.convertInt16Position = function(x, y) {
+    return {
+        x: ViomiMapParser.convertFloat(x),
+        y: ViomiMapParser.MAX_MAP_HEIGHT - ViomiMapParser.convertFloat(y)
+    };
 };
 
 ViomiMapParser.MAX_MAP_HEIGHT = ViomiMapParser.convertFloat(20); // 40000

--- a/lib/ViomiMapParser.js
+++ b/lib/ViomiMapParser.js
@@ -1,4 +1,5 @@
 const Logger = require("./Logger");
+/** @typedef {Array<number>} Pose */
 
 /**
  * Experimental parser for the Viomi map binary format.
@@ -176,6 +177,7 @@ ViomiMapParser.prototype.parse = function() {
     // TODO: one of them is just the room outline, not actual past navigation logic
     return {
         image: this.img,
+        zones: this.rooms,
         path: {points: this.points.length ? this.points : this.history},
         goto_target: this.navigateTarget.position,
         robot: this.realtimePose.position,
@@ -206,7 +208,7 @@ ViomiMapParser.prototype.parsePose = function() {
             ]);
             this.offset += 5;
         }
-        this.rooms[roomId].pose = pose;
+        this.rooms[roomId].outline = pose;
     }
 };
 
@@ -237,6 +239,7 @@ ViomiMapParser.prototype.parseRooms = function() {
     } while (mapArg > 1);
 
     let length = this.take(4, "room length").readUInt32LE(0);
+    /** @type {Object<number, {name: string, outline?: Array<Pose>}>} */
     let rooms = {};
     for (let i = 0; i < length; i++) {
         let nameLen = this.buf.readUInt8(this.offset + 1);

--- a/lib/devices/MiioVacuum.js
+++ b/lib/devices/MiioVacuum.js
@@ -146,6 +146,9 @@ class MiioVacuum {
         return Promise.reject("not implemented");
     }
 
+    /** @param {Array<number>} zone_ids */
+    async startCleaningZonesById(zone_ids) {}
+
     async shutdown() {
         Logger.debug("MiioVacuum shutdown in progress...");
         await this.dummycloud.shutdown();

--- a/lib/devices/Roborock.js
+++ b/lib/devices/Roborock.js
@@ -515,7 +515,7 @@ class Roborock extends MiioVacuum {
         zone_ids.forEach((zone_id) => {
             let zone = zones.get(zone_id);
             if (zone) {
-                areasToClean.concat(zone.areas);
+                areasToClean = areasToClean.concat(zone.areas);
                 zoneNames.push(zone.name);
             }
         });

--- a/lib/devices/Roborock.js
+++ b/lib/devices/Roborock.js
@@ -5,7 +5,7 @@ const Tools = require("../Tools");
 const RRMapParser = require("../RRMapParser");
 
 /**
- * @implements {MiioVacuum}
+ * @extends {MiioVacuum}
  */
 class Roborock extends MiioVacuum {
     /**
@@ -505,33 +505,40 @@ class Roborock extends MiioVacuum {
         return await this.sendLocal("app_goto_target", [x_coord, 51200 - y_coord], {});
     }
 
-    async startCleaningZoneByName(zones) {
-        let areas = this.configuration.get("areas");
-        zones = Array.isArray(zones) ? zones : [ zones ];
-        let zonesToClean = [];
+    /** @param {Array<number>} zone_ids */
+    async startCleaningZonesById(zone_ids) {
+        let zones = this.configuration.getZones();
+        /** @type {Array<import('../Configuration').Area>} */
+        let areasToClean = [];
+        /** @type {Array<string>} */
         let zoneNames = [];
-        zones.forEach(function (zone_id) {
-            let area = areas.find(e => Array.isArray(e) && e[0] === zone_id);
-            if (area && Array.isArray(area[1])) {
-                area[1].forEach(function (zone) {
-                    zonesToClean.push(zone);
-                });
-                zoneNames.push(area[0]);
+        zone_ids.forEach((zone_id) => {
+            let zone = zones.get(zone_id);
+            if (zone) {
+                areasToClean.concat(zone.areas);
+                zoneNames.push(zone.name);
             }
         });
-        if (zonesToClean.length && zoneNames.length){
+        if (areasToClean.length && zoneNames.length) {
             this.zoneCleaningStatus = zoneNames;
-            await this.startCleaningZoneByCoords(zonesToClean);
+            await this.startCleaningZoneByCoords(areasToClean);
         } else {
             throw new Error("Zone names not found.");
         }
     }
 
+    /**
+     * Returns the names of currently cleaned Zones
+     * @returns {Array<string>}
+     */
     getZoneCleaningStatus() {
         return this.zoneCleaningStatus;
     }
 
-    /* zones is an array of areas to clean:  [[x1, y1, x2, y2, iterations],..] */
+    /**
+     * @param {Array<Array<number>>} zones is an array of areas to clean:  [[x1, y1, x2, y2,
+     *     iterations],..]
+     */
     async startCleaningZoneByCoords(zones) {
         if (Array.isArray(zones) && zones.length <= 5) {
             const flippedZones = zones.map(zone => {

--- a/lib/devices/Viomi.js
+++ b/lib/devices/Viomi.js
@@ -4,6 +4,23 @@ const MiioVacuum = require("./MiioVacuum");
 const ViomiMapParser = require("../ViomiMapParser");
 
 /**
+ * Converts an area rect spec to a viomi zone.
+ * @param {Array<import('../Configuration').Area>} areas
+ * @param {boolean} restricted Whether this is the spec for restricted areas
+ * @returns string
+ */
+function toZoneSpec(areas, restricted) {
+    const mode = restricted ? 2 : 0;
+    return areas.map((area, index) => {
+        const a = ViomiMapParser.positionToViomi(area[0], area[1]);
+        const b = ViomiMapParser.positionToViomi(area[2], area[3]);
+        // Compute all the 4 corner points of the rectangle.
+        const coords = [a.x, a.y, a.x, b.y, b.x, b.y, b.x, a.y];
+        return `${index}_${mode}_` + coords.map(v => "" + v).join("_");
+    });
+}
+
+/**
  * Implements the viomi.vacuum.v7 device.
  * Still incomplete contributions are welcome.
  * @implements {MiioVacuum}
@@ -147,11 +164,29 @@ class Viomi extends MiioVacuum {
 
     /** @param {Array<number>} zone_ids */
     async startCleaningZonesById(zone_ids) {
-        const mode = 0;
+        let mode = 0;
         const zones = this.configuration.getZones();
-        zone_ids = zone_ids.filter(z => !zones.get(z).user);
-        return await this.sendLocal("set_mode_withroom",
-            [mode, 1, zone_ids.length].concat(zone_ids));
+        const zone_ids_from_map = zone_ids.filter(id => !zones.get(id).user);
+        const zones_from_user = zone_ids.map(id => zones.get(id)).filter(z => z.user);
+        if (zone_ids_from_map.length && zones_from_user.length) {
+            throw new Error("Cannot start cleaning rooms and custom zones simultaneously");
+        }
+        if (zone_ids_from_map.length) {
+            /** @type {Array} */
+            const args = [mode, 1, zone_ids_from_map.length];
+            return await this.sendLocal("set_mode_withroom", args.concat(zone_ids_from_map));
+        } else if (zones_from_user.length) {
+            const areas = [];
+            zones_from_user.forEach(z => areas.push(...z.areas));
+            const specs = toZoneSpec(areas, /*restricted=*/ false);
+            /** @type {Array} */
+            const args = [specs.length];
+            await this.sendLocal("set_zone", args.concat(specs));
+            mode = 3; // zoned clean
+            return await this.sendLocal("set_mode", [mode, 1]);
+        } else {
+            throw new Error("No zones to clean");
+        }
     }
 
     stopCleaning() {

--- a/lib/devices/Viomi.js
+++ b/lib/devices/Viomi.js
@@ -106,7 +106,15 @@ class Viomi extends MiioVacuum {
 
     parseMap(data) {
         try {
-            return new ViomiMapParser(data).parse();
+            const map = new ViomiMapParser(data).parse();
+            const zones = this.configuration.getZones();
+            zones.forEach((v, k) => v.user || zones.delete(k));
+            Object.entries(map.zones).map(v => {
+                const id = parseInt(v[0]);
+                zones.set(id, {id: id, name: v[1].name, user: false});
+            });
+            this.configuration.setZones(zones);
+            return map;
         } catch (e) {
             // save map data for later debugging
             let i = 0;
@@ -135,6 +143,15 @@ class Viomi extends MiioVacuum {
 
     driveHome() {
         return this.sendLocal("set_charge", [1]);
+    }
+
+    /** @param {Array<number>} zone_ids */
+    async startCleaningZonesById(zone_ids) {
+        const mode = 0;
+        const zones = this.configuration.getZones();
+        zone_ids = zone_ids.filter(z => !zones.get(z).user);
+        return await this.sendLocal("set_mode_withroom",
+            [mode, 1, zone_ids.length].concat(zone_ids));
     }
 
     stopCleaning() {

--- a/lib/res/default_settings.json
+++ b/lib/res/default_settings.json
@@ -1,6 +1,5 @@
 {
     "spots": [],
-    "areas": [],
     "mqtt" : {
         "enabled": false,
         "identifier": "rockrobo",

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -447,10 +447,10 @@ const WebServer = function (options) {
     });
 
     /* New function with support of current zone cleanup */
-    this.app.put("/api/start_cleaning_zone_by_name", async (req, res) => {
+    this.app.put("/api/start_cleaning_zones_by_id", async (req, res) => {
         try {
             if (req.body) {
-                let data = await this.vacuum.startCleaningZoneByName(req.body);
+                let data = await this.vacuum.startCleaningZonesById(req.body);
                 res.json(data);
             } else {
                 res.status(400).send("coordinates missing");
@@ -461,23 +461,29 @@ const WebServer = function (options) {
     });
 
     this.app.get("/api/zones", async (req, res) => {
-        // Todo: rename areas to zones in config
-        const zones = this.configuration.get("areas");
-
-        res.json(zones.map(zone => ({
-            name: zone[0],
-            coordinates: zone[1]
-        })));
+        const zones = [...this.configuration.getZones().values()];
+        res.json(zones);
     });
 
     this.app.put("/api/zones", async (req, res) => {
         if (req.body && Array.isArray(req.body)) {
             // Todo: Extended validation
-            const zones = req.body.map(zone => [
-                zone.name,
-                zone.coordinates
-            ]);
-            this.configuration.set("areas", zones);
+            const zones = this.configuration.getZones();
+            const found = new Set();
+            req.body.map(zone => {
+                /** @type {Object} */
+                const oldZone = zones.get(zone.id);
+                if (oldZone) {
+                    Object.assign(oldZone, zone);
+                }
+                found.add(zone.id);
+            });
+            zones.forEach((v, k) => {
+                if (!found.has(k) && v.user) {
+                    zones.delete(k);
+                }
+            });
+            this.configuration.setZones(zones);
             res.status(201).json({message: "ok"});
         } else {
             res.status(400).send("bad request body");

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -475,6 +475,8 @@ const WebServer = function (options) {
                 const oldZone = zones.get(zone.id);
                 if (oldZone) {
                     Object.assign(oldZone, zone);
+                } else {
+                    zones.set(zone.id, zone);
                 }
                 found.add(zone.id);
             });


### PR DESCRIPTION
For Viomi the Robot itself keeps track of rooms.
Exposing those with the zones interface allows the UI to start cleaning them manually.

They are otherwise filtered from the UI. This should thus be a no-op for Roborock, except that the `// Todo: rename areas to zones in config` comment was addressed and some more type-safety was added.