### PR TITLE
MQTT go_to command

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -394,6 +394,16 @@ class MqttClient {
                 }
                 /**
                  * {
+                 *   "command": "app_segment_clean",
+                 *   "params": [room_id]
+                 * }
+                 */
+                case CUSTOM_COMMANDS.APP_SEGMENT_CLEAN: {
+                    Logger.info("Custom command 'app_segment_clean' is currently not supported");
+                    break;
+                }
+                /**
+                 * {
                  *   "command": "app_zoned_clean",
                  *   "params": [[x1, y1, x2, y2, iterations],..]
                  * }
@@ -437,11 +447,6 @@ class MqttClient {
                  * }
                  */
                 case CUSTOM_COMMANDS.GO_TO:
-                    // TODO remove
-                    // msg.spot_id is an array of exactly 2 values considered to be coordinates
-                    // if (Array.isArray(msg.spot_id) && msg.spot_id.length === 2) {
-                    //     this.vacuum.goTo(msg.spot_id[0], msg.spot_id[1]);
-                    // } else
                     if (msg.spot_id) {
                         const spots = this.configuration.get("spots");
                         const spot_coords = spots.find(e => Array.isArray(e) && e[0] === msg.spot_id);

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -383,12 +383,7 @@ class MqttClient {
                  *   "params": [x, y]
                  * }
                  */
-                // entity_id: vacuum.rose       <---------------------------------------------------------------------------------------
-                // command: app_goto_target     <---------------------------------------------------------------------------------------
-                // params:                      <---------------------------------------------------------------------------------------
-                //   params: [11,22]            <---------------------------------------------------------------------------------------
                 case CUSTOM_COMMANDS.APP_GOTO_TARGET: {
-                    // TODO <-----------------------------------------------------------------------------------------------------------
                     const coords = msg["params"];
                     if (Array.isArray(coords) && coords.length===2) {
                         this.vacuum.goTo(coords[0], coords[1])
@@ -404,7 +399,6 @@ class MqttClient {
                  * }
                  */
                 case CUSTOM_COMMANDS.APP_ZONED_CLEAN: {
-                    // TODO <-----------------------------------------------------------------------------------------------------------
                     const zones = msg["params"];
                     this.vacuum.startCleaningZoneByCoords(zones).catch(err => {
                         Logger.error(err);

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -415,7 +415,7 @@ class MqttClient {
                 case CUSTOM_COMMANDS.GO_TO:
                     // msg.spot_id is an array of exactly 2 values considered to be coordinates
                     if (Array.isArray(msg.spot_id) && msg.spot_id.length === 2) {
-            	        this.vacuum.goTo(msg.spot_id[0], msg.spot_id[1]);
+                        this.vacuum.goTo(msg.spot_id[0], msg.spot_id[1]);
                     } else if (msg.spot_id) {
                         const spots = this.configuration.get("spots");
                         const spot_coords = spots.find(e => Array.isArray(e) && e[0] === msg.spot_id);

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -379,6 +379,40 @@ class MqttClient {
             switch (msg.command) {
                 /**
                  * {
+                 *   "command": "app_goto_target",
+                 *   "params": [x, y]
+                 * }
+                 */
+                // entity_id: vacuum.rose       <---------------------------------------------------------------------------------------
+                // command: app_goto_target     <---------------------------------------------------------------------------------------
+                // params:                      <---------------------------------------------------------------------------------------
+                //   params: [11,22]            <---------------------------------------------------------------------------------------
+                case CUSTOM_COMMANDS.APP_GOTO_TARGET: {
+                    // TODO <-----------------------------------------------------------------------------------------------------------
+                    const coords = msg["params"];
+                    if (Array.isArray(coords) && coords.length===2) {
+                        this.vacuum.goTo(coords[0], coords[1])
+                    } else {
+                        Logger.info("Missing coords or array of wrong length");
+                    }
+                    break;
+                }
+                /**
+                 * {
+                 *   "command": "app_zoned_clean",
+                 *   "params": [[x1, y1, x2, y2, iterations],..]
+                 * }
+                 */
+                case CUSTOM_COMMANDS.APP_ZONED_CLEAN: {
+                    // TODO <-----------------------------------------------------------------------------------------------------------
+                    const zones = msg["params"];
+                    this.vacuum.startCleaningZoneByCoords(zones).catch(err => {
+                        Logger.error(err);
+                    });
+                    break;
+                }
+                /**
+                 * {
                  *   "command": "zoned_cleanup",
                  *   "zone_ids": [
                  *     "Foobar",
@@ -387,41 +421,6 @@ class MqttClient {
                  * }
                  * Note: that zone_ids can be a mix of Zone IDs (numbers) and zone names.
                  */
-                case CUSTOM_COMMANDS.APP_GOTO_TARGET: {
-                    // vacuumGoToPoint(debug) {
-                    //     const mapPos = this.convertMapToVacuumCoordinates(this.currPoint.x, this.currPoint.y);
-                    //     if (debug && this._config.debug) {
-                    //         alert(JSON.stringify([mapPos.x, mapPos.y]));
-                    //     } else {
-                    //         this._hass.callService(this.service_domain, this.service_method, {
-                    //             entity_id: this._config.entity,
-                    //             command: "app_goto_target",
-                    //             params: [mapPos.x, mapPos.y]
-                    //         }).then(() => this.showToast());
-                    //     }
-                    // }
-                    // TODO
-                    break;
-                }
-                case CUSTOM_COMMANDS.APP_ZONED_CLEAN: {
-                    // vacuumStartZonedCleanup(debug) {
-                    //     const zone = [];
-                    //     for (const rect of this.rectangles) {
-                    //         zone.push(this.convertMapToVacuumRect(rect, this.vacuumZonedCleanupRepeats));
-                    //     }
-                    //     if (debug && this._config.debug) {
-                    //         alert(JSON.stringify(zone));
-                    //     } else {
-                    //         this._hass.callService(this.service_domain, this.service_method, {
-                    //             entity_id: this._config.entity,
-                    //             command: "app_zoned_clean",
-                    //             params: zone
-                    //         }).then(() => this.showToast());
-                    //     }
-                    // }
-                    // TODO
-                    break;
-                }
                 case CUSTOM_COMMANDS.ZONED_CLEANUP: {
                     const zones = msg["zone_ids"];
                     if (Array.isArray(zones) && zones.length) {
@@ -448,7 +447,7 @@ class MqttClient {
                     // msg.spot_id is an array of exactly 2 values considered to be coordinates
                     // if (Array.isArray(msg.spot_id) && msg.spot_id.length === 2) {
                     //     this.vacuum.goTo(msg.spot_id[0], msg.spot_id[1]);
-                    // } else 
+                    // } else
                     if (msg.spot_id) {
                         const spots = this.configuration.get("spots");
                         const spot_coords = spots.find(e => Array.isArray(e) && e[0] === msg.spot_id);

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -404,9 +404,19 @@ class MqttClient {
                  *   "command": "go_to",
                  *   "spot_id": "Somewhere"
                  * }
+                 *
+                 * or (with xxx and yyy being coordinates)
+                 *
+                 * {
+                 *   "command": "go_to",
+                 *   "spot_id": [xxx, yyy]
+                 * }
                  */
                 case CUSTOM_COMMANDS.GO_TO:
-                    if (msg.spot_id) {
+                    // msg.spot_id is an array of exactly 2 values considered to be coordinates
+                    if (Array.isArray(msg.spot_id) && msg.spot_id.length === 2) {
+            	        this.vacuum.goTo(msg.spot_id[0], msg.spot_id[1]);
+                    } else if (msg.spot_id) {
                         const spots = this.configuration.get("spots");
                         const spot_coords = spots.find(e => Array.isArray(e) && e[0] === msg.spot_id);
 

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -13,8 +13,11 @@ const MQTT_COMMANDS = {
 };
 
 const CUSTOM_COMMANDS = {
+    APP_GOTO_TARGET: "app_goto_target",
+    APP_SEGMENT_CLEAN: "app_segment_clean",
+    APP_ZONED_CLEAN: "app_zoned_clean",
     GO_TO: "go_to",
-    ZONED_CLEANUP: "zoned_cleanup"
+    ZONED_CLEANUP: "zoned_cleanup",
 };
 
 //TODO: since this is also displayed in the UI it should be moved somewhere else
@@ -384,6 +387,41 @@ class MqttClient {
                  * }
                  * Note: that zone_ids can be a mix of Zone IDs (numbers) and zone names.
                  */
+                case CUSTOM_COMMANDS.APP_GOTO_TARGET: {
+                    // vacuumGoToPoint(debug) {
+                    //     const mapPos = this.convertMapToVacuumCoordinates(this.currPoint.x, this.currPoint.y);
+                    //     if (debug && this._config.debug) {
+                    //         alert(JSON.stringify([mapPos.x, mapPos.y]));
+                    //     } else {
+                    //         this._hass.callService(this.service_domain, this.service_method, {
+                    //             entity_id: this._config.entity,
+                    //             command: "app_goto_target",
+                    //             params: [mapPos.x, mapPos.y]
+                    //         }).then(() => this.showToast());
+                    //     }
+                    // }
+                    // TODO
+                    break;
+                }
+                case CUSTOM_COMMANDS.APP_ZONED_CLEAN: {
+                    // vacuumStartZonedCleanup(debug) {
+                    //     const zone = [];
+                    //     for (const rect of this.rectangles) {
+                    //         zone.push(this.convertMapToVacuumRect(rect, this.vacuumZonedCleanupRepeats));
+                    //     }
+                    //     if (debug && this._config.debug) {
+                    //         alert(JSON.stringify(zone));
+                    //     } else {
+                    //         this._hass.callService(this.service_domain, this.service_method, {
+                    //             entity_id: this._config.entity,
+                    //             command: "app_zoned_clean",
+                    //             params: zone
+                    //         }).then(() => this.showToast());
+                    //     }
+                    // }
+                    // TODO
+                    break;
+                }
                 case CUSTOM_COMMANDS.ZONED_CLEANUP: {
                     const zones = msg["zone_ids"];
                     if (Array.isArray(zones) && zones.length) {
@@ -404,19 +442,14 @@ class MqttClient {
                  *   "command": "go_to",
                  *   "spot_id": "Somewhere"
                  * }
-                 *
-                 * or (with xxx and yyy being coordinates)
-                 *
-                 * {
-                 *   "command": "go_to",
-                 *   "spot_id": [xxx, yyy]
-                 * }
                  */
                 case CUSTOM_COMMANDS.GO_TO:
+                    // TODO remove
                     // msg.spot_id is an array of exactly 2 values considered to be coordinates
-                    if (Array.isArray(msg.spot_id) && msg.spot_id.length === 2) {
-                        this.vacuum.goTo(msg.spot_id[0], msg.spot_id[1]);
-                    } else if (msg.spot_id) {
+                    // if (Array.isArray(msg.spot_id) && msg.spot_id.length === 2) {
+                    //     this.vacuum.goTo(msg.spot_id[0], msg.spot_id[1]);
+                    // } else 
+                    if (msg.spot_id) {
                         const spots = this.configuration.get("spots");
                         const spot_coords = spots.find(e => Array.isArray(e) && e[0] === msg.spot_id);
 

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -386,7 +386,7 @@ class MqttClient {
                 case CUSTOM_COMMANDS.APP_GOTO_TARGET: {
                     const coords = msg["params"];
                     if (Array.isArray(coords) && coords.length===2) {
-                        this.vacuum.goTo(coords[0], coords[1])
+                        this.vacuum.goTo(coords[0], coords[1]);
                     } else {
                         Logger.info("Missing coords or array of wrong length");
                     }


### PR DESCRIPTION
added possibility to give the spot_id as coordinates in addition to the name.

Something similar could be done for zoned cleanup to be fully compatible with
https://github.com/PiotrMachowski/Lovelace-Xiaomi-Vacuum-Map-card
