### PR TITLE
Expose zone changes over Mqtt

### DIFF
--- a/lib/Events.js
+++ b/lib/Events.js
@@ -17,6 +17,17 @@ class Events {
         this.eventEmitter.on(Events.MapUpdated, listener);
     }
 
+    emitZonesChanged() {
+        this.eventEmitter.emit(Events.ZonesChanged);
+    }
+
+    /**
+     * @param {() => void} listener
+     */
+    onZonesChanged(listener) {
+        this.eventEmitter.on(Events.ZonesChanged, listener);
+    }
+
     /**
      * @param {import("./miio/Status")} status
      */
@@ -44,6 +55,7 @@ class Events {
 }
 
 Events.MapUpdated = "MapUpdated";
+Events.ZonesChanged = "ZonesChanged";
 Events.StatusUpdated = "StatusUpdated";
 Events.MqttConfigChanged = "MqttConfigChanged";
 

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -80,6 +80,12 @@ class MqttClient {
             }
         });
 
+        this.events.onZonesChanged(() => {
+            if (this.provideMapData === true) {
+                this.updateZonesTopic();
+            }
+        });
+
         this.events.onStatusUpdated((statusData) => {
             this.updateStatusTopic(statusData);
             this.updateAttributesTopicOnEvent(statusData);
@@ -116,6 +122,7 @@ class MqttClient {
             send_command: this.topicPrefix + "/" + this.identifier + "/custom_command",
             state: this.topicPrefix + "/" + this.identifier + "/state",
             map_data: this.topicPrefix + "/" + this.identifier + "/map_data",
+            zones: this.topicPrefix + "/" + this.identifier + "/zones",
             attributes: this.topicPrefix + "/" + this.identifier + "/attributes",
             homeassistant_autoconf_vacuum: this.autoconfPrefix + "/vacuum/" + this.topicPrefix + "_" + this.identifier + "/config",
         };
@@ -221,6 +228,20 @@ class MqttClient {
     updateMapDataTopic(mapDTO) {
         if (this.client && this.client.connected === true && mapDTO && mapDTO.parsedData) {
             this.client.publish(this.topics.map_data, JSON.stringify(mapDTO.parsedData), {retain: true, qos:this.qos});
+        }
+    }
+
+    /**
+     * @private
+     */
+    updateZonesTopic() {
+        if (this.client && this.client.connected === true) {
+            var json_data = {
+                zones: [...this.configuration.getZones().values()]
+            };
+            this.client.publish(this.topics.zones, JSON.stringify(json_data), {
+                retain: true, qos:this.qos
+            });
         }
     }
 

--- a/lib/devices/Viomi.js
+++ b/lib/devices/Viomi.js
@@ -219,6 +219,7 @@ class Viomi extends MiioVacuum {
                 zones.set(id, {id: id, name: v[1].name, user: false});
             });
             this.configuration.setZones(zones);
+            this.events.emitZonesChanged();
             return map;
         } catch (e) {
             // save map data for later debugging

--- a/lib/webserver/ApiRouter.js
+++ b/lib/webserver/ApiRouter.js
@@ -384,6 +384,7 @@ const ApiRouter = function(webserver) {
                 }
             });
             configuration.setZones(zones);
+            events.emitZonesChanged();
             res.sendStatus(201);
         } else {
             res.status(400).send("bad request body");


### PR DESCRIPTION
Fixes #102.

Broadcasts to `/zones` on change, same data as `/api/zones` but prefixed with "zones" so that Home Assistant is okay with parsing it as a JSON attribute:
![image](https://user-images.githubusercontent.com/1885159/81099353-14869d00-8f0b-11ea-8fea-8c3fc8a0f1b3.png)

Example Home Assistant configuration.yaml:
```yaml
sensor:
  - platform: mqtt
    state_topic: "valetudo/rockrobo/state"
    json_attributes_topic: "valetudo/rockrobo/zones"
    name: xiaomi_map_zones
    value_template: 'OK'
    scan_interval: 5
```

![image](https://user-images.githubusercontent.com/1885159/81099434-354ef280-8f0b-11ea-8b18-cfc3fedc5640.png)

(P.S.: What's the 1 as the last value of an area and why is id null and -1?)