### PR TITLE
Adds time and area information about current clean to MQTT

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -77,6 +77,8 @@ class MqttClient {
         this.last_ha_state = HA_STATES.IDLE;
         this.last_state = "UNKNOWN";
         this.last_attributes = {};
+        this.last_cleaned_area = 0;
+        this.last_cleaning_time = 0;
 
         this.loadConfig();
         if (this.enabled) {
@@ -240,6 +242,8 @@ class MqttClient {
     updateAttributesTopicOnEvent(statusData) {
         this.last_ha_state = HA_STATE_MAPPINGS[statusData.state];
         this.last_state = statusData.state;
+        this.last_cleaned_area = statusData.clean_area ? (statusData.clean_area / 1000000).toFixed(1) : 0;
+        this.last_cleaning_time = statusData.clean_time ? (statusData.clean_time / 60).toFixed(1) : 0;
 
         this.updateAttributesTopic();
     }
@@ -266,6 +270,8 @@ class MqttClient {
                 response.cleanTime = round(cleanSummary.cleanTime, 1);
                 response.cleanArea = round(cleanSummary.cleanArea, 1);
                 response.cleanCount = cleanSummary.cleanCount;
+                response.cleaned_area = this.last_cleaned_area;
+                response.cleaning_time = this.last_cleaning_time;
                 let last_runs = cleanSummary.lastRuns;
                 if (last_runs.length > 0) {
                     try {

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -317,6 +317,8 @@ class MqttClient {
             response.state = HA_STATE_MAPPINGS[statusData.state];
             response.battery_level = statusData.battery;
             response.fan_speed = statusData.fan_power;
+            response.cleaned_area = statusData.clean_area ? (statusData.clean_area / 1000000).toFixed(1) : 0;
+            response.cleaning_time = statusData.clean_time ? (statusData.clean_time / 60).toFixed(1) : 0;
 
             if (statusData.error_code !== undefined && statusData.error_code !== 0) {
                 response.error = statusData.human_error;

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -242,8 +242,8 @@ class MqttClient {
     updateAttributesTopicOnEvent(statusData) {
         this.last_ha_state = HA_STATE_MAPPINGS[statusData.state];
         this.last_state = statusData.state;
-        this.last_cleaned_area = statusData.clean_area ? (statusData.clean_area / 1000000).toFixed(1) : 0;
-        this.last_cleaning_time = statusData.clean_time ? (statusData.clean_time / 60).toFixed(1) : 0;
+        this.last_cleaned_area = statusData.clean_area ? parseFloat((statusData.clean_area / 1000000).toFixed(2)) : 0;
+        this.last_cleaning_time = statusData.clean_time ? parseFloat((statusData.clean_time / 60).toFixed(1)) : 0;
 
         this.updateAttributesTopic();
     }
@@ -270,8 +270,8 @@ class MqttClient {
                 response.cleanTime = round(cleanSummary.cleanTime, 1);
                 response.cleanArea = round(cleanSummary.cleanArea, 1);
                 response.cleanCount = cleanSummary.cleanCount;
-                response.cleaned_area = this.last_cleaned_area;
-                response.cleaning_time = this.last_cleaning_time;
+                response.lastCleanedArea = this.last_cleaned_area;
+                response.lastCleaningTime = this.last_cleaning_time;
                 let last_runs = cleanSummary.lastRuns;
                 if (last_runs.length > 0) {
                     try {


### PR DESCRIPTION
I wasn't able to find the current clean time nor cleaning area in the MQTT output, so I added these following the format in the Xiaomi Home Assistant integration (i.e. `cleaning_time` and `cleaned_area` from https://www.home-assistant.io/integrations/vacuum.xiaomi_miio/).

Allows showing active cleaning information in HA, such as the following card:
![image](https://user-images.githubusercontent.com/1933511/81622871-c284c200-93b7-11ea-9979-6917da7b1df1.png)
