### PR TITLE
Update roborock install instractions

### DIFF
--- a/docs/_pages/installation/roborock.md
+++ b/docs/_pages/installation/roborock.md
@@ -88,8 +88,8 @@ It is recommended to use [https://github.com/zvldz/vacuum](https://github.com/zv
 You can create a folder with all the needed things with the commands like:
 
 ```
-git clone https://github.com/Hypfer/Valetudo.git /tmp/Valetudo
-cd /tmp/Valetudo
+git clone https://github.com/Hypfer/Valetudo.git
+cd ./Valetudo
 wget https://github.com/Hypfer/Valetudo/releases/latest/download/valetudo
 ```
 
@@ -102,7 +102,7 @@ Please refer to this command-line example and edit it according to your setup:
                         --enable-greeting \
                         --disable-logs \
                         --replace-adbd \
-                        --valetudo-path=/tmp/Valetudo \
+                        --valetudo-path=./Valetudo \
                         --replace-miio \
                         --enable-dns-catcher \
                         -f path_to_firmware.pkg

--- a/docs/_pages/installation/roborock.md
+++ b/docs/_pages/installation/roborock.md
@@ -80,8 +80,19 @@ Example: https://dustbuilder.xvm.mit.edu/pkg/s5/v11_002008.fullos.fd043420-6ddb-
 ### Image Building
 It is recommended to use [https://github.com/zvldz/vacuum](https://github.com/zvldz/vacuum) to build the image.
 
-`--valetudo-path` expects a path to a folder containing a binary named `valetudo`.
-Refer to [https://github.com/Hypfer/Valetudo/releases](https://github.com/Hypfer/Valetudo/releases) to fetch the latest valetudo binary.
+`--valetudo-path` expects a path to a folder containing two things:
+
+ * The source code of [Valetudo](https://github.com/Hypfer/Valetudo)
+ * And a binary named `valetudo`.  Refer to [https://github.com/Hypfer/Valetudo/releases](https://github.com/Hypfer/Valetudo/releases) to fetch the latest valetudo binary.
+
+You can create a folder will all the needed things with the commands like:
+(but make sure to use the latest version from the [releases](https://github.com/Hypfer/Valetudo/releases) page)
+
+```
+git clone https://github.com/Hypfer/Valetudo.git /tmp/Valetudo
+cd /tmp/Valetudo
+wget https://github.com/Hypfer/Valetudo/releases/download/0.5.1/valetudo
+```
 
 Please refer to this command-line example and edit it according to your setup:
 ```
@@ -92,7 +103,7 @@ Please refer to this command-line example and edit it according to your setup:
                         --enable-greeting \
                         --disable-logs \
                         --replace-adbd \
-                        --valetudo-path=./Valetudo \
+                        --valetudo-path=/tmp/Valetudo \
                         --replace-miio \
                         --enable-dns-catcher \
                         -f path_to_firmware.pkg

--- a/docs/_pages/installation/roborock.md
+++ b/docs/_pages/installation/roborock.md
@@ -83,15 +83,14 @@ It is recommended to use [https://github.com/zvldz/vacuum](https://github.com/zv
 `--valetudo-path` expects a path to a folder containing two things:
 
  * The source code of [Valetudo](https://github.com/Hypfer/Valetudo)
- * And a binary named `valetudo`.  Refer to [https://github.com/Hypfer/Valetudo/releases](https://github.com/Hypfer/Valetudo/releases) to fetch the latest valetudo binary.
+ * And a binary named `valetudo`. Refer to https://github.com/Hypfer/Valetudo/releases to fetch the latest valetudo binary.
 
-You can create a folder will all the needed things with the commands like:
-(but make sure to use the latest version from the [releases](https://github.com/Hypfer/Valetudo/releases) page)
+You can create a folder with all the needed things with the commands like:
 
 ```
 git clone https://github.com/Hypfer/Valetudo.git /tmp/Valetudo
 cd /tmp/Valetudo
-wget https://github.com/Hypfer/Valetudo/releases/download/0.5.1/valetudo
+wget https://github.com/Hypfer/Valetudo/releases/latest/download/valetudo
 ```
 
 Please refer to this command-line example and edit it according to your setup:


### PR DESCRIPTION
I'm spend a lot of time installing Valetudo on my Xiaomi Gen 1.
At last I've managed to flash the new software to the robot,
but it turned out that Valetudo is not starting.

After some investigation I have found the source of the problem.
The script builder_vacuum.sh parameter --valetudo-path=
should get not only the binary, but also some files
valetudo.conf, hosts and rc.local

I've asked the author of  builder_vacuum.sh and he said that the
best way is just to pass the whole git repo. But the compiled file
is also needed.

By the way, the script builder_vacuum.sh is already updated to
show errors:
https://github.com/zvldz/vacuum/commit/b27d536448df4b3cff798a9c6ad36f6eb387ae79
