### PR TITLE
Add Availability topic to let Home Assistant also detect an offline robot

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -50,8 +50,8 @@ const HA_STATE_MAPPINGS = {
     "PAUSED": HA_STATES.PAUSED,
 };
 
-const HA_ONLINE_STATUS = 'online'
-const HA_OFFLINE_STATUS = 'offline'
+const HA_ONLINE_STATUS = "online";
+const HA_OFFLINE_STATUS = "offline";
 
 /**
  * @param {number} number
@@ -170,7 +170,7 @@ class MqttClient {
                 payload: HA_OFFLINE_STATUS,
                 qos: this.qos,
                 retain: true,
-            }
+            };
 
             this.client = mqtt.connect(
                 (this.usetls ? "mqtts://" : "mqtt://") + this.server + ":" + this.port,
@@ -258,7 +258,7 @@ class MqttClient {
         this.client.publish(this.topics.homeassistant_autoconf_vacuum, JSON.stringify(autoconf_payloads.vacuum), {
             retain: true, qos:this.qos
         });
-        this.client.publish(this.topics.availability, HA_ONLINE_STATUS, {retain: true, qos: this.qos})
+        this.client.publish(this.topics.availability, HA_ONLINE_STATUS, {retain: true, qos: this.qos});
     }
 
     /**

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -50,6 +50,9 @@ const HA_STATE_MAPPINGS = {
     "PAUSED": HA_STATES.PAUSED,
 };
 
+const HA_ONLINE_STATUS = 'online'
+const HA_OFFLINE_STATUS = 'offline'
+
 /**
  * @param {number} number
  * @param {number} precision number of decimal digits
@@ -148,6 +151,7 @@ class MqttClient {
             map_data: this.topicPrefix + "/" + this.identifier + "/map_data",
             attributes: this.topicPrefix + "/" + this.identifier + "/attributes",
             homeassistant_autoconf_vacuum: this.autoconfPrefix + "/vacuum/" + this.topicPrefix + "_" + this.identifier + "/config",
+            availability: this.topicPrefix + "/" + this.identifier + "/status",
         };
     }
 
@@ -161,6 +165,12 @@ class MqttClient {
             if (this.username) options.username = this.username;
             if (this.password) options.password = this.password;
             if (this.caPath) options.ca = fs.readFileSync(this.caPath);
+            options.will = {
+                topic: this.topics.availability,
+                payload: HA_OFFLINE_STATUS,
+                qos: this.qos,
+                retain: true,
+            }
 
             this.client = mqtt.connect(
                 (this.usetls ? "mqtts://" : "mqtt://") + this.server + ":" + this.port,
@@ -240,13 +250,15 @@ class MqttClient {
                 set_fan_speed_topic: this.topics.set_fan_speed,
                 fan_speed_list: Object.keys(await this.vacuum.getFanSpeeds()),
                 send_command_topic: this.topics.send_command,
-                json_attributes_topic: this.topics.attributes
+                json_attributes_topic: this.topics.attributes,
+                availability_topic: this.topics.availability
             }
         };
 
         this.client.publish(this.topics.homeassistant_autoconf_vacuum, JSON.stringify(autoconf_payloads.vacuum), {
             retain: true, qos:this.qos
         });
+        this.client.publish(this.topics.availability, HA_ONLINE_STATUS, {retain: true, qos: this.qos})
     }
 
     /**

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -50,8 +50,10 @@ const HA_STATE_MAPPINGS = {
     "PAUSED": HA_STATES.PAUSED,
 };
 
-const HA_ONLINE_STATUS = "online";
-const HA_OFFLINE_STATUS = "offline";
+const HA_AVAILABILITY_STATES = {
+    ONLINE: "online",
+    OFFLINE: "offline"
+};
 
 /**
  * @param {number} number
@@ -167,7 +169,7 @@ class MqttClient {
             if (this.caPath) options.ca = fs.readFileSync(this.caPath);
             options.will = {
                 topic: this.topics.availability,
-                payload: HA_OFFLINE_STATUS,
+                payload: HA_AVAILABILITY_STATES.OFFLINE,
                 qos: this.qos,
                 retain: true,
             };
@@ -258,7 +260,7 @@ class MqttClient {
         this.client.publish(this.topics.homeassistant_autoconf_vacuum, JSON.stringify(autoconf_payloads.vacuum), {
             retain: true, qos:this.qos
         });
-        this.client.publish(this.topics.availability, HA_ONLINE_STATUS, {retain: true, qos: this.qos});
+        this.client.publish(this.topics.availability, HA_AVAILABILITY_STATES.ONLINE, {retain: true, qos: this.qos});
     }
 
     /**


### PR DESCRIPTION
This MR adds a Last Will and Testament mechanism which tells Home Assistant about the current connection status.

The `online` status is only sent once at startup and the MQTT broker will set it to `offline` when the connection to Valetudo was lost.

