### PR TITLE
Don't open forbidden zones editor if model is gen 1 

### DIFF
--- a/client/zones.html
+++ b/client/zones.html
@@ -10,14 +10,16 @@
     <ons-list id="spot-list">
         <ons-list-item>No spots are configured yet.</ons-list-item>
     </ons-list>
-
-    <ons-list-title style="margin-top:20px;">Forbidden markers</ons-list-title>
-    <ons-list id="spot-list">
-         <ons-list-item tappable class="locations-list-item" onclick="switchToForbiddenMarkersEdit()">
-             <label><ons-icon icon="edit"></ons-icon></label>
-             <label>Configure forbidden zones</label>
-         </ons-list-item>
-    </ons-list>
+    
+    <div id="forbidden-zones-item" hidden>
+        <ons-list-title style="margin-top:20px;">Forbidden markers</ons-list-title>
+        <ons-list id="forbidden-zones-list">
+             <ons-list-item tappable class="locations-list-item" onclick="switchToForbiddenMarkersEdit()">
+                 <label><ons-icon icon="edit"></ons-icon></label>
+                 <label>Configure forbidden zones</label>
+             </ons-list-item>
+        </ons-list>
+    </div>
 
     <script>
       {

--- a/client/zones.js
+++ b/client/zones.js
@@ -5,6 +5,7 @@ import {ApiService} from "./services/api.service.js";
 let loadingBarZones = document.getElementById("loading-bar-zones");
 let zonesList = document.getElementById("zones-list");
 let spotList = document.getElementById("spot-list");
+let forbiddenZonesItem = document.getElementById("forbidden-zones-item");
 
 /** @type {Array<{id:number, name:string, user: boolean, areas: Array}>} */
 let zonesConfig = [];
@@ -207,6 +208,17 @@ async function ZonesInit() {
     try {
         spotConfig = await ApiService.getSpots();
         generateSpotList();
+    } catch (err) {
+        ons.notification.toast(err.message,
+            {buttonLabel: "Dismiss", timeout: window.fn.toastErrorTimeout});
+    }
+
+    /* forbidden zones are not supported by gen 1 vacuums */
+    try {
+        let modelConfig = await ApiService.getModel();
+        if (modelConfig.identifier !== "rockrobo.vacuum.v1") {
+            forbiddenZonesItem.hidden = false;
+        }
     } catch (err) {
         ons.notification.toast(err.message,
             {buttonLabel: "Dismiss", timeout: window.fn.toastErrorTimeout});


### PR DESCRIPTION
Fix for https://github.com/Hypfer/Valetudo/issues/382

When the "Configure forbidden zones" button is pressed on a gen 1, a toast is shown ("Not supported by your device").

I hope it's okay that the check is done when the button is pressed. 
Maybe it'd be better to disable/hide the button right away?