### PR TITLE
docs: update information about supported roborock devices

### DIFF
--- a/docs/_pages/knowledge_base/supported-roborock-devices.md
+++ b/docs/_pages/knowledge_base/supported-roborock-devices.md
@@ -32,7 +32,7 @@ There are only two Buttons on this model.
 Also, the charging contacts are found on the back side of the robot.
 
 ![Gen 1 Label](./img/devices/roborock/gen1-label.jpg)
-Please note that Gen 1 Vacuums with a production date >= 2019-09 may come with newer firmwares preinstalled which disables
+Please note that Gen 1 Vacuums with a production [date >= 2019-09 (ver >= 4004)](https://twitter.com/dgi_DE/status/1273742178783805441) may come with newer firmwares preinstalled which disables
 local OTA and thus **making the Installation of Valetudo impossible without opening the device.**
 
 We don't know yet when they've exactly started manufacturing them like that, however there's at least
@@ -79,7 +79,7 @@ There are _three_ Buttons on an S5.
 **Please note that the S5 Max is a different Model than the S5.**
 
 ![Gen 2 S55 Label](./img/devices/roborock/gen2-s55-label.jpg)
-Make sure to always check the production date of the unit, since units with a production date >= 2019-09 may come with
+Make sure to always check the production date of the unit, since units with a production [date >= 2019-11 (ver >= 2008)](https://twitter.com/dgi_DE/status/1273742178783805441) may come with
 newer firmwares preinstalled which disables local OTA and thus **making the Installation of Valetudo impossible without opening the device.**
 
 Compared to the Gen 1, the Gen 2 can climb higher obstacles and features persistent maps.

--- a/lib/Valetudo.js
+++ b/lib/Valetudo.js
@@ -131,7 +131,8 @@ const MODEL_TO_IMPLEMENTATION = {
     "roborock.vacuum.s5e": RoborockGen3,
     "roborock.vacuum.t4": RoborockGen3,
     "roborock.vacuum.s4": RoborockGen3,
-    "roborock.vacuum.m1s": RoborockGen3
+    "roborock.vacuum.m1s": RoborockGen3,
+    "roborock.vacuum.a10": RoborockGen3
 };
 
 module.exports = Valetudo;

--- a/lib/miio/Model.js
+++ b/lib/miio/Model.js
@@ -181,7 +181,8 @@ const MODELS = {
         "t6": "T6",
         "s4": "S4",
         "t4": "T4",
-        "1s": "1S"
+        "1s": "1S",
+        "a10": "S6 MaxV"
     },
     "rockrobo": {
         "v1": "Xiaomi Mi SDJQR02RR"


### PR DESCRIPTION
model=viomi.vacuum.v8  (STYTJ02YM - Mi Robot Vacuum-Mop P / Production Date: 01/2020)

To get this working on a V8 I simply replaced the text v7 with v8 in the following files before compiling. Using tcpdump I also noticed that my box was trying to connect to de.ot.io.mi.com, so I needed to add this to the local host file.

./lib/miio/Model.js:            "persistent_data": this.identifier !== "rockrobo.vacuum.v1" && this.identifier !== "viomi.vacuum.v7"
./lib/Valetudo.js:    "viomi.vacuum.v7": Viomi,
./lib/devices/Viomi.js: * Implements the viomi.vacuum.v7 device.


/etc/hosts
110.43.0.83 de.ot.io.mi.com ot.io.mi.com ott.io.mi.com


tested on original firmware Ver: 3.5.3_0014