### PR TITLE
Fix map coloring

### DIFF
--- a/client/zone/js-modules/map-color-finder.js
+++ b/client/zone/js-modules/map-color-finder.js
@@ -12,7 +12,7 @@ export class FourColorTheoremSolver {
      */
     constructor(layers, resolution) {
         const prec = Math.floor(resolution);
-        this.stepFunction = function(c) {
+        this.stepFunction = function (c) {
             return c + prec;
         };
         var preparedLayers = this.preprocessLayers(layers);
@@ -179,19 +179,24 @@ class MapAreaGraph {
 
     /**
      * Color the graphs vertices using a greedy algorithm. Any vertices that have already been assigned a color will not be changed.
+     * Color assignment will start with the vertex that is connected with the highest number of edges. In most cases, this will
+     * naturally lead to a distribution where only four colors are required for the whole graph. This is relevant for maps with a high
+     * number of segments, as the naive, greedy algorithm tends to require a fifth color when starting coloring in a segment far from the map's center.
+     * 
      */
     colorAllVertices() {
-        this.vertices.forEach(v => {
-            if (v.adjacentVertexIds.size <= 0) {
-                v.color = 0;
-            } else {
-                var adjs = this.getAdjacentVertices(v);
-                var existingColors = adjs
-                    .filter(vert => vert.color !== undefined)
-                    .map(vert => vert.color);
-                v.color = this.lowestColor(existingColors);
-            }
-        });
+        this.vertices.sort((l, r) => r.adjacentVertexIds.size - l.adjacentVertexIds.size)
+            .forEach(v => {
+                if (v.adjacentVertexIds.size <= 0) {
+                    v.color = 0;
+                } else {
+                    var adjs = this.getAdjacentVertices(v);
+                    var existingColors = adjs
+                        .filter(vert => vert.color !== undefined)
+                        .map(vert => vert.color);
+                    v.color = this.lowestColor(existingColors);
+                }
+            });
     }
 
     getAdjacentVertices(vertex) {

--- a/client/zone/js-modules/map-color-finder.js
+++ b/client/zone/js-modules/map-color-finder.js
@@ -56,7 +56,7 @@ export class FourColorTheoremSolver {
         }
         filteredLayers.forEach(layer => {
             var allPixels = [];
-            for (let index = 0; index < layer.pixels.length / 2; index += 2) {
+            for (let index = 0; index < layer.pixels.length - 1; index += 2) {
                 var p = {
                     x: layer.pixels[index],
                     y: layer.pixels[index + 1]

--- a/client/zone/js-modules/map-color-finder.js
+++ b/client/zone/js-modules/map-color-finder.js
@@ -16,8 +16,8 @@ export class FourColorTheoremSolver {
             return c + prec;
         };
         var preparedLayers = this.preprocessLayers(layers);
-        var map = this.createPixelToSegmentMapping(preparedLayers);
-        this.areaGraph = this.buildGraph(map);
+        var mapData = this.createPixelToSegmentMapping(preparedLayers);
+        this.areaGraph = this.buildGraph(mapData);
         this.areaGraph.colorAllVertices();
     }
 
@@ -36,7 +36,6 @@ export class FourColorTheoremSolver {
     }
 
     preprocessLayers(layers) {
-        var segmentCounter = 0;
         var internalSegments = [];
         var boundaries = {
             minX: Infinity,
@@ -56,7 +55,7 @@ export class FourColorTheoremSolver {
                     allPixels.push(p);
                 }
                 internalSegments.push({
-                    segmentIndex: segmentCounter++,
+                    segmentId: layer.metaData.segmentId,
                     pixels: allPixels
                 });
             });
@@ -86,22 +85,22 @@ export class FourColorTheoremSolver {
             preparedLayers.boundaries.maxX + 1,
             preparedLayers.boundaries.maxY + 1
         );
-        var numberOfSegments = 0;
+        var segmentIds = [];
         preparedLayers.segments.forEach(seg => {
-            numberOfSegments += 1;
+            segmentIds.push(seg.segmentId);
             seg.pixels.forEach(p => {
-                pixelData[p.x][p.y] = seg.segmentIndex;
+                pixelData[p.x][p.y] = seg.segmentId;
             });
         });
         return {
             map: pixelData,
-            numberOfSegments: numberOfSegments,
+            segmentIds: segmentIds,
             boundaries: preparedLayers.boundaries
         };
     }
 
     buildGraph(mapData) {
-        var vertices = this.range(mapData.numberOfSegments).map(i => new MapAreaVertex(i));
+        var vertices = mapData.segmentIds.map(i => new MapAreaVertex(i));
         var graph = new MapAreaGraph(vertices);
         this.traverseMap(mapData.boundaries, mapData.map, (x, y, currentSegmentId, pixelData) => {
             var newSegmentId = pixelData[x][y];
@@ -141,10 +140,6 @@ export class FourColorTheoremSolver {
             }
         }
         return arr;
-    }
-
-    range(n) {
-        return Array.apply(null, { length: n }).map(Number.call, Number);
     }
 }
 

--- a/client/zone/js-modules/map-drawer.js
+++ b/client/zone/js-modules/map-drawer.js
@@ -32,7 +32,8 @@ export function MapDrawer() {
             "#19A1A1",
             "#7AC037",
             "#DF5618",
-            "#F7C841"
+            "#F7C841",
+            "#9966CC" // "fallback" color
         ].map(function (e) {
             return hexToRgb(e);
         });
@@ -61,10 +62,9 @@ export function MapDrawer() {
                         break;
                 }
 
-
                 if (!color) {
-                    console.error(`Missing color for ${layer.type} with segment id '${layer.metaData.segmentId}'. Using fallback color.`);
-                    color = hexToRgb("#9966cc");
+                    console.error(`Missing color for ${layer.type} with segment id '${layer.metaData.segmentId}'.`);
+                    color = {r: 0, g: 0, b: 0};
                 }
 
                 for (let i = 0; i < layer.pixels.length; i = i + 2) {

--- a/client/zone/js-modules/map-drawer.js
+++ b/client/zone/js-modules/map-drawer.js
@@ -56,15 +56,15 @@ export function MapDrawer() {
                         color = occupiedColor;
                         break;
                     case "segment":
-                        color = segmentColors[colorFinder.getColor((layer.metaData.segmentId - 1))];
+                        color = segmentColors[colorFinder.getColor((layer.metaData.segmentId))];
                         alpha = 192;
                         break;
                 }
 
 
                 if (!color) {
-                    console.error("Missing color for " + layer.type);
-                    color = {r: 0, g: 0, b: 0};
+                    console.error(`Missing color for ${layer.type} with segment id '${layer.metaData.segmentId}'. Using fallback color.`);
+                    color = hexToRgb("#9966cc");
                 }
 
                 for (let i = 0; i < layer.pixels.length; i = i + 2) {

--- a/client/zone/js-modules/map-drawer.js
+++ b/client/zone/js-modules/map-drawer.js
@@ -41,7 +41,7 @@ export function MapDrawer() {
         mapCtx.clearRect(0, 0, mapCanvas.width, mapCanvas.height);
         const imgData = mapCtx.createImageData(mapCanvas.width, mapCanvas.height);
 
-        const colorFinder = new FourColorTheoremSolver(layers, 4);
+        const colorFinder = new FourColorTheoremSolver(layers, 6);
 
         if (layers && layers.length > 0) {
             layers.forEach(layer => {

--- a/client/zone/js-modules/map-drawer.js
+++ b/client/zone/js-modules/map-drawer.js
@@ -41,7 +41,7 @@ export function MapDrawer() {
         mapCtx.clearRect(0, 0, mapCanvas.width, mapCanvas.height);
         const imgData = mapCtx.createImageData(mapCanvas.width, mapCanvas.height);
 
-        const colorFinder = new FourColorTheoremSolver(layers, 6);
+        const colorFinder = new FourColorTheoremSolver(layers, 4);
 
         if (layers && layers.length > 0) {
             layers.forEach(layer => {


### PR DESCRIPTION
This resolves #566 by changing the segment identification.
Previously, the vertices in the internal graph were indexed by generating a sequence, starting at zero. This PR uses the original segment ID from the attached meta data instead, resulting in correct color resolution when given this ID.
When coloring the graph, the algorithm now sorts the vertices by their number of adjacent vertices in descending order. This is not perfect though and does not *guarantee* that the result will only contain four colors from a mathematical standpoint. However, for all my test cases, this approach did use only four colors.

Additionally, I added a fifth color to the map drawer. Any edge case that is still not resolved by this fix should then fall back to this fifth color.