### PR TITLE
Send state to MQTT only if it has been changed

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -79,6 +79,7 @@ class MqttClient {
 
         this.last_ha_state = HA_STATES.IDLE;
         this.last_state = "UNKNOWN";
+        this.last_status = {};
         this.last_attributes = {};
         this.last_cleaned_area = 0;
         this.last_cleaning_time = 0;
@@ -452,7 +453,10 @@ class MqttClient {
                 response.cleaning_time = 0;
             }
 
-            this.client.publish(this.topics.state, JSON.stringify(response), {retain: true, qos:this.qos});
+            if (JSON.stringify(response) !== JSON.stringify(this.last_status)) {
+                this.client.publish(this.topics.state, JSON.stringify(response), {retain: true, qos:this.qos});
+                this.last_status = response;
+            }
         }
     }
 


### PR DESCRIPTION
Valetudo sends state every 60s even it has same values. It's not necessary because messages sent with retain flag.