### PR TITLE
Add support for no-mopping zones on S5 Max and S6

### DIFF
--- a/client/forbidden-markers-configuration-map.html
+++ b/client/forbidden-markers-configuration-map.html
@@ -16,6 +16,9 @@
         <ons-fab ripple id="forbidden-markers-configuration-add-zone">
             <ons-icon icon="fa-window-close-o"></ons-icon>
         </ons-fab>
+        <ons-fab ripple id="forbidden-markers-configuration-add-mop-zone">
+            <ons-icon icon="fa-stop-circle-o"></ons-icon>
+        </ons-fab>
         <ons-fab ripple id="forbidden-markers-configuration-save">
             <ons-icon icon="fa-save"></ons-icon>
         </ons-fab>

--- a/client/forbidden-markers-configuration-map.js
+++ b/client/forbidden-markers-configuration-map.js
@@ -13,11 +13,17 @@ function markerConfigInit() {
 
 
     const no_go_areas = topPage.data.map.entities.filter(e => e.type === "no_go_area");
+    const no_mop_areas = topPage.data.map.entities.filter(e => e.type === "no_mop_area");
     const virtual_walls = topPage.data.map.entities.filter(e => e.type === "virtual_wall");
 
     if (no_go_areas) {
         no_go_areas.forEach(area => {
             map.addForbiddenZone(area.points, true, true);
+        });
+    }
+    if (no_mop_areas) {
+        no_mop_areas.forEach(area => {
+            map.addForbiddenMopZone(area.points, true, true);
         });
     }
 
@@ -40,6 +46,11 @@ function markerConfigInit() {
             map.addForbiddenZone(null, false, true);
         };
 
+    document.getElementById("forbidden-markers-configuration-add-mop-zone")
+        .onclick = () => {
+            map.addForbiddenMopZone(null, false, true);
+        };
+
     saveButton.onclick = async () => {
         loadingBarSaveMarkers.setAttribute("indeterminate", "indeterminate");
         saveButton.setAttribute("disabled", "disabled");
@@ -47,7 +58,8 @@ function markerConfigInit() {
         try {
             await ApiService.setPersistentData(
                 map.getLocations().virtualWalls,
-                map.getLocations().forbiddenZones
+                map.getLocations().forbiddenZones,
+                map.getLocations().forbiddenMopZones
             );
             await ons.notification.toast(
                 "Successfully saved forbidden markers!",

--- a/client/services/api.service.js
+++ b/client/services/api.service.js
@@ -97,10 +97,11 @@ export class ApiService {
         });
     }
 
-    static async setPersistentData(virtualWalls, no_go_areas) {
+    static async setPersistentData(virtualWalls, no_go_areas, no_mop_areas) {
         await this.fetch("PUT", "api/persistent_data", {
             virtual_walls: virtualWalls,
-            no_go_areas: no_go_areas
+            no_go_areas: no_go_areas,
+            no_mop_areas: no_mop_areas
         });
     }
 

--- a/lib/RRMapParser.js
+++ b/lib/RRMapParser.js
@@ -20,6 +20,7 @@ const BlockTypes = {
     "NO_GO_AREAS": 9,
     "VIRTUAL_WALLS": 10,
     "CURRENTLY_CLEANED_SEGMENTS": 11,
+    "NO_MOP_AREAS": 12,
     "DIGEST": 1024
 };
 
@@ -121,6 +122,8 @@ class RRMapParser {
             case BlockTypes.VIRTUAL_WALLS:
                 return this.PARSE_STRUCTURES_BLOCK(block, false);
             case BlockTypes.NO_GO_AREAS:
+                return this.PARSE_STRUCTURES_BLOCK(block, true);
+            case BlockTypes.NO_MOP_AREAS:
                 return this.PARSE_STRUCTURES_BLOCK(block, true);
             case BlockTypes.CURRENTLY_CLEANED_SEGMENTS:
                 return this.PARSE_SEGMENTS_BLOCK(block);
@@ -494,6 +497,21 @@ class RRMapParser {
                             }
                         }),
                         type: Map.LineMapEntity.TYPE.VIRTUAL_WALL
+                    }));
+                });
+            }
+
+            if (blocks[BlockTypes.NO_MOP_AREAS]) {
+                blocks[BlockTypes.NO_MOP_AREAS].forEach(area => {
+                    entities.push(new Map.PolygonMapEntity({
+                        points: area.map((p, i) => {
+                            if (i % 2 === 0) {
+                                return Math.round(p/10);
+                            } else {
+                                return Math.round((RRMapParser.DIMENSION_MM - p)/10);
+                            }
+                        }),
+                        type: Map.PolygonMapEntity.TYPE.NO_MOP_AREA
                     }));
                 });
             }

--- a/lib/devices/RoborockGen3.js
+++ b/lib/devices/RoborockGen3.js
@@ -1,4 +1,5 @@
 const RoborockS5 = require("./RoborockS5");
+const RRMapParser = require("../RRMapParser");
 
 /*
     This class is a hackish way to support S6/S5 Max without changing much of the code
@@ -21,6 +22,67 @@ class RoborockGen3 extends RoborockS5 {
         super.detectFanSpeeds(3); //lol hack
     }
 
+    /**
+     * Saves the persistent data like virtual walls, nogo zones, and no-mop zones
+     * They have to be provided in the following format:
+     *      https://github.com/marcelrv/XiaomiRobotVacuumProtocol/issues/15#issuecomment-447647905
+     *      Software barrier takes a vector of [id, x1,y1,x2,y2]
+     *      And no-go zone takes [id, x1,y1,x2,y2,x3,y3,x4,y4], which are the corners of the zone rectangle?
+     *      Edit: see @JensBuchta's comment. The first parameter appears to be a type: 0 = zone, 1 = barrier, 2 = no-mop zone
+     *
+     * @param {any} persistantData
+     */
+    async savePersistentData(persistantData) { //TODO: Store in valetudo config
+        if (Array.isArray(persistantData)) {
+            const flippedYCoordinates = persistantData.map(data => {
+                if (data[0] === PERSISTENT_DATA_TYPES.ZONE || data[0] === PERSISTENT_DATA_TYPES.NOMOP) {
+                    // this is a no-go zone or a no-mop zone
+                    return [
+                        data[0],
+                        data[1] * 10,
+                        RRMapParser.DIMENSION_MM - data[2] * 10,
+                        data[3] * 10,
+                        RRMapParser.DIMENSION_MM - data[4] * 10,
+                        data[5] * 10,
+                        RRMapParser.DIMENSION_MM - data[6] * 10,
+                        data[7] * 10,
+                        RRMapParser.DIMENSION_MM - data[8] * 10
+                    ];
+                } else {
+                    // this is a barrier
+                    return [
+                        data[0],
+                        data[1] * 10,
+                        RRMapParser.DIMENSION_MM - data[2] * 10,
+                        data[3] * 10,
+                        RRMapParser.DIMENSION_MM - data[4] * 10,
+                    ];
+                }
+            });
+
+            if (flippedYCoordinates.reduce((total, currentElem) => {
+                return total += currentElem[0] === PERSISTENT_DATA_TYPES.ZONE ? 4 : 2;
+            }, 0) > 68) {
+                throw new Error("too many forbidden markers to save!");
+            }
+
+
+            this.sendCommand("save_map", flippedYCoordinates, {timeout: 3500}).finally(() => {
+                this.pollMap();
+            });
+        } else {
+            throw new Error("persistantData has to be an array.");
+        }
+    }
+
+
 }
+
+/** @enum {number} */
+const PERSISTENT_DATA_TYPES = {
+    "ZONE": 0,
+    "BARRIER": 1,
+    "NOMOP": 2
+};
 
 module.exports = RoborockGen3;

--- a/lib/entities/map/PolygonMapEntity.js
+++ b/lib/entities/map/PolygonMapEntity.js
@@ -20,7 +20,8 @@ class PolygonMapEntity extends MapEntity {
  */
 PolygonMapEntity.TYPE = Object.freeze({
     ACTIVE_ZONE: "active_zone",
-    NO_GO_AREA: "no_go_area"
+    NO_GO_AREA: "no_go_area",
+    NO_MOP_AREA: "no_mop_area"
 });
 
 module.exports = PolygonMapEntity;

--- a/lib/webserver/ApiRouter.js
+++ b/lib/webserver/ApiRouter.js
@@ -383,10 +383,12 @@ const ApiRouter = function (webserver) {
             if (req.body !== undefined
                 && Array.isArray(req.body.virtual_walls)
                 && Array.isArray(req.body.no_go_areas)
+                && Array.isArray(req.body.no_mop_areas)
             ) {
                 const persistentData = [
                     ...req.body.no_go_areas.map(area => [0, ...area]),
-                    ...req.body.virtual_walls.map(wall => [1, ...wall])
+                    ...req.body.virtual_walls.map(wall => [1, ...wall]),
+                    ...req.body.no_mop_areas.map(area => [2, ...area])
                 ];
 
                 if (model.getCapabilities().persistent_data === true) {
@@ -396,7 +398,7 @@ const ApiRouter = function (webserver) {
                     res.status(501).send("saving persistentData is supported only on Roborock S50/55");
                 }
             } else {
-                res.status(400).send("bad request body. Should look like { \"virtual_walls\": [], \"no_go_areas\": []}");
+                res.status(400).send("bad request body. Should look like { \"virtual_walls\": [], \"no_go_areas\": [], \"no_mop_areas\": []}");
             }
         } catch (err) {
             res.status(500).send(err.toString());


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/7981005/100304522-8fc1a600-2f64-11eb-9ad5-b1b765d34e22.png)


No-mopping zones are like no-go zones, but they are only active when mopping. Very useful for drawing around rugs and carpets. They are available on the S5 Max and the S6, but not the S5. The screenshot above shows how the robot is forced to take an alternate route because of a no-mop zone in the way. 

They can be added in the _Configure forbidden zones_ view of Valetudo. They show up purple to match the stock Mi-Home app. 

I have tested the functionality on my S6 and everything works correctly. I expect it will work fine on the S5 max as well, but I don't have one. 

## Known Issues:

- The button to create a no-mop zone will still appear on the S5. So we will need some way to conditionally display buttons in the _Configure forbidden zones_ page. This is sort of an architectural decision, so I would like to hear suggestions. 

- I wasn't able to find a suitable icon in the provided FontAwesome pack. So I just chose a placeholder for now. [tint-slash](https://fontawesome.com/icons/tint-slash?style=regular) could work nicely. 