### PR TITLE
Set VALETUDO_CONFIG_PATH variable for Upstart

### DIFF
--- a/deployment/valetudo.conf
+++ b/deployment/valetudo.conf
@@ -1,6 +1,8 @@
 #!upstart
 description "Valetudo"
 
+env VALETUDO_CONFIG_PATH=/mnt/data/valetudo/valetudo_config.json
+
 start on started network-interface INTERFACE=wlan0
 stop on runlevel [06]
 


### PR DESCRIPTION
Fix vanishing configuration on each reboot for devices with Upstart.