### PR TITLE
Roborock/Capability Spot Clean

### DIFF
--- a/client/home.js
+++ b/client/home.js
@@ -296,6 +296,10 @@ async function updateHomePage() {
                     buttonStateMap.spot = false;
                     buttonStateMap.go_to = false;
                     buttonStateMap.zones = false;
+                    switch (StatusStateAttribute.flag) {
+                        case "spot":
+                            buttonStateMap.stop = false;
+                    }
                     break;
                 case "paused":
                     buttonStateMap.stop = false;

--- a/client/services/api.service.js
+++ b/client/services/api.service.js
@@ -55,7 +55,7 @@ export class ApiService {
     }
 
     static async spotClean() {
-        await this.fetch("PUT", "api/spot_clean");
+        await this.fetch("PUT", "api/v2/robot/capabilities/SpotCleaningCapability");
     }
 
     /**

--- a/lib/core/capabilities/SpotCleaningCapability.js
+++ b/lib/core/capabilities/SpotCleaningCapability.js
@@ -1,0 +1,20 @@
+const Capability = require("./Capability");
+const NotImplementedError = require("../NotImplementedError");
+
+class SpotCleaningCapability extends Capability {
+    /**
+     * @abstract
+     * @returns {Promise<void>}
+     */
+    async spotClean() {
+        throw new NotImplementedError();
+    }
+
+    getType() {
+        return SpotCleaningCapability.TYPE;
+    }
+}
+
+SpotCleaningCapability.TYPE = "SpotCleaningCapability";
+
+module.exports = SpotCleaningCapability;

--- a/lib/core/capabilities/index.js
+++ b/lib/core/capabilities/index.js
@@ -18,4 +18,5 @@ module.exports = {
     SensorCalibrationCapability: require("./SensorCalibrationCapability"),
     SpeakerVolumeControlCapability: require("./SpeakerVolumeControlCapability"),
     RawCommandCapability: require("./RawCommandCapability"),
+    SpotCleaningCapability: require("./SpotCleaningCapability"),
 };

--- a/lib/robots/roborock/RoborockValetudoRobot.js
+++ b/lib/robots/roborock/RoborockValetudoRobot.js
@@ -43,6 +43,9 @@ class RoborockValetudoRobot extends MiioValetudoRobot {
         this.registerCapability(new capabilities.RoborockLocateCapability({
             robot: this
         }));
+        this.registerCapability(new capabilities.RoborockSpotCleaningCapability({
+            robot: this
+        }));
     }
 
     setEmbeddedParameters() {

--- a/lib/robots/roborock/capabilities/RoborockSpotCleaningCapability.js
+++ b/lib/robots/roborock/capabilities/RoborockSpotCleaningCapability.js
@@ -1,0 +1,13 @@
+const SpotCleaningCapability = require("../../../core/capabilities/SpotCleaningCapability");
+
+class RoborockSpotCleaningCapability extends SpotCleaningCapability {
+    /**
+     * @abstract
+     * @returns {Promise<void>}
+     */
+    async spotClean() {
+        await this.robot.sendCommand("app_spot", [], {});
+    }
+}
+
+module.exports = RoborockSpotCleaningCapability;

--- a/lib/robots/roborock/capabilities/index.js
+++ b/lib/robots/roborock/capabilities/index.js
@@ -10,5 +10,6 @@ module.exports = {
     RoborockCombinedVirtualRestrictionsCapability: require("./RoborockCombinedVirtualRestrictionsCapability"),
     RoborockPersistentMapControlCapability: require("./RoborockPersistentMapControlCapability"),
     RoborockMultiMapPersistentMapControlCapability: require("./RoborockMultiMapPersistentMapControlCapability"),
-    RoborockMapSegmentationCapability: require("./RoborockMapSegmentationCapability")
+    RoborockMapSegmentationCapability: require("./RoborockMapSegmentationCapability"),
+    RoborockSpotCleaningCapability: require("./RoborockSpotCleaningCapability")
 };

--- a/lib/webserver/CapabilitiesRouter.js
+++ b/lib/webserver/CapabilitiesRouter.js
@@ -69,7 +69,8 @@ const CAPABILITY_TYPE_TO_ROUTER_MAPPING = {
     [capabilities.SensorCalibrationCapability.TYPE]: capabilityRouters.SensorCalibrationCapabilityRouter,
     [capabilities.SpeakerVolumeControlCapability.TYPE]: capabilityRouters.SpeakerVolumeControlCapabilityRouter,
     [capabilities.RawCommandCapability.TYPE]: capabilityRouters.RawCommandCapabilityRouter,
-    [capabilities.MapSegmentationCapability.TYPE]: capabilityRouters.MapSegmentationCapabilityRouter
+    [capabilities.MapSegmentationCapability.TYPE]: capabilityRouters.MapSegmentationCapabilityRouter,
+    [capabilities.SpotCleaningCapability.TYPE]: capabilityRouters.SpotCleaningCapabilityRouter
 };
 
 module.exports = CapabilitiesRouter;

--- a/lib/webserver/capabilityRouters/SpotCleaningCapabilityRouter.js
+++ b/lib/webserver/capabilityRouters/SpotCleaningCapabilityRouter.js
@@ -1,0 +1,24 @@
+const Logger = require("../../Logger");
+
+const CapabilityRouter = require("./CapabilityRouter");
+
+class SpotCleaningCapabilityRouter extends CapabilityRouter {
+
+    initRoutes() {
+        this.router.put("/", async (req, res) => {
+            if (req.body) {
+                try {
+                    await this.capability.spotClean();
+                    res.sendStatus(200);
+                } catch (e) {
+                    Logger.warn("Error while initiating spot cleaning", e);
+                    res.status(500).json(e.message);
+                }
+            } else {
+                res.status(404);
+            }
+        });
+    }
+}
+
+module.exports = SpotCleaningCapabilityRouter;

--- a/lib/webserver/capabilityRouters/index.js
+++ b/lib/webserver/capabilityRouters/index.js
@@ -14,5 +14,6 @@ module.exports = {
     SensorCalibrationCapabilityRouter: require("./SensorCalibrationCapabilityRouter"),
     SpeakerVolumeControlCapabilityRouter: require("./SpeakerVolumeControlCapabilityRouter"),
     RawCommandCapabilityRouter: require("./RawCommandCapabilityRouter"),
-    MapSegmentationCapabilityRouter: require("./MapSegmentationCapabilityRouter")
+    MapSegmentationCapabilityRouter: require("./MapSegmentationCapabilityRouter"),
+    SpotCleaningCapabilityRouter: require("./SpotCleaningCapabilityRouter")
 };


### PR DESCRIPTION
Spot cleaning capability for Roborock vacuums added now button on main page functions.  Updated button matrix to disable the stop button when in spot cleaning mode as only the pause function initiates a change in function upon testing with a Gen 1 vacuum.

Function could be replaced at some point with a small fixed zone configuration at a later stage.  Unable to find support for equivalent feature outside of Roborock range.