### PR TITLE
Remove initial slash to the EventSource url, so it becomes relative instead of absolute.

### DIFF
--- a/client/zone/js-modules/vacuum-map.js
+++ b/client/zone/js-modules/vacuum-map.js
@@ -37,7 +37,7 @@ export function VacuumMap(canvasElement) {
 
     function initSSE() {
         console.info("SSE Connecting");
-        evtSource = new EventSource("/api/v2/robot/state/map/sse", {withCredentials: true});
+        evtSource = new EventSource("api/v2/robot/state/map/sse", {withCredentials: true});
 
 
         evtSource.addEventListener("MapUpdated", (event) => {


### PR DESCRIPTION
Please, note that I was unable to test and validate the fix (because of troubles to build binary).

When accessed through a proxy server with a "subfolder" (in my case using ProxyPass, see https://httpd.apache.org/docs/2.4/fr/mod/mod_proxy.html) the map is not updated in realtime, but it is when switching tab and back to map tab.

The reason seems to comes from the absolute path used in vacuum-map.js, ignoring potential subfolder introduced by the proxy.

Ex : 
Real robot address is :
- http://192.168.x.x/
accessed and redirected through
- http://my-domain.com/robot/

So the requested url is
- http://my-domain.com/api/v2/robot/state/map/sse
instead of
- http://my-domain.com/robot/api/v2/robot/state/map/sse

resulting in 404 errors, and so the map is not updated in real-time.