### PR TITLE
Block ott.io.mi.com requests (for unimplemented TCP dummycloud)

### DIFF
--- a/lib/robots/MiioValetudoRobot.js
+++ b/lib/robots/MiioValetudoRobot.js
@@ -103,64 +103,6 @@ class MiioValetudoRobot extends ValetudoRobot {
             }
         });
 
-        // clang-format off
-        /*
-        Handle viomi load balancing requests:
-
-        GET /gslb?tver=2&id=277962183&dm=ot.io.mi.com&timestamp=1574455630&sign=nNevMcHtzuB90okJfG9zSyPTw87u8U8HQpVNXqpVt%2Bk%3D HTTP/1.1
-        Host:110.43.0.83
-        User-Agent:miio-client
-
-        {
-            "info": {
-                "host_list": [{
-                        "ip": "120.92.65.244",
-                        "port": 8053
-                    }, {
-                        "ip": "120.92.142.94",
-                        "port": 8053
-                    }, {
-                        "ip": "58.83.177.237",
-                        "port": 8053
-                    }, {
-                        "ip": "58.83.177.239",
-                        "port": 8053
-                    }, {
-                        "ip": "58.83.177.236",
-                        "port": 8053
-                    }, {
-                        "ip": "120.92.65.242",
-                        "port": 8053
-                    }
-                ],
-                "enable": 1
-            },
-            "sign": "NxPNmsa8eh2/Y6OdJKoEaEonR6Lvrw5CkV5+mnpZois=",
-            "timestamp": "1574455630"
-        }
-        */
-        // clang-format on
-        this.expressApp.get("/gslb", (req, res) => {
-            const info = {
-                "host_list": [
-                    {
-                        "ip": this.embeddedDummycloudIp,
-                        "port": Dummycloud.PORT
-                    }
-                ],
-                "enable": 1
-            };
-            const signature = crypto.createHmac("sha256", this.cloudSecret)
-                .update(JSON.stringify(info))
-                .digest("base64");
-
-            res.status(200).send({
-                "info": info,
-                "timestamp": req.query["timestamp"],
-                "sign": signature
-            });
-        });
-
         this.mapUploadServer.listen(8079, this.dummycloudBindIp, function() {
             Logger.info("Map Upload Server running on port " + 8079);
         });
@@ -226,6 +168,71 @@ class MiioValetudoRobot extends ValetudoRobot {
     setEmbeddedParameters() {
         this.deviceConfPath = "/dev/null";
         this.tokenFilePath = "/dev/null";
+    }
+
+    // clang-format off
+    /*
+    Handles http_dns load balancing requests.
+
+    Example request and response (the latter is pretty-printed for readability).
+
+    GET /gslb?tver=2&id=277962183&dm=ot.io.mi.com&timestamp=1574455630&sign=nNevMcHtzuB90okJfG9zSyPTw87u8U8HQpVNXqpVt%2Bk%3D HTTP/1.1
+    Host:110.43.0.83
+    User-Agent:miio-client
+
+    {
+        "info": {
+            "host_list": [{
+                    "ip": "120.92.65.244",
+                    "port": 8053
+                }, {
+                    "ip": "120.92.142.94",
+                    "port": 8053
+                }, {
+                    "ip": "58.83.177.237",
+                    "port": 8053
+                }, {
+                    "ip": "58.83.177.239",
+                    "port": 8053
+                }, {
+                    "ip": "58.83.177.236",
+                    "port": 8053
+                }, {
+                    "ip": "120.92.65.242",
+                    "port": 8053
+                }
+            ],
+            "enable": 1
+        },
+        "sign": "NxPNmsa8eh2/Y6OdJKoEaEonR6Lvrw5CkV5+mnpZois=",
+        "timestamp": "1574455630"
+    }
+    */
+    // clang-format on
+    handleHttpDnsRequest(req, res) {
+        // ot.io.mi.com asks for UDP host
+        // ott.io.mi.com asks for TCP hosts, which our dummycloud doesn’t (yet) support.
+        if (req.query["dm"] === "ott.io.mi.com") {
+            res.status(501).send("miio/tcp not implemented");
+        }
+        const info = {
+            "host_list": [
+                {
+                    "ip": this.embeddedDummycloudIp,
+                    "port": 8053
+                }
+            ],
+            "enable": 1
+        };
+        const signature = crypto.createHmac("sha256", this.cloudSecret)
+            .update(JSON.stringify(info))
+            .digest("base64");
+
+        res.status(200).send({
+            "info": info,
+            "timestamp": req.query["timestamp"],
+            "sign": signature
+        });
     }
 
     /**

--- a/lib/webserver/WebServer.js
+++ b/lib/webserver/WebServer.js
@@ -98,31 +98,11 @@ class WebServer {
              This is a hack for miio vacuums with a recent miio_client
 
              To properly spoof the http_dns request, we need to have this route on port 80 instead of the
-             miio-implementation specific second webserver on 8087 :/
+             miio-implementation specific second webserver on 8079 :/
          */
         if (this.robot instanceof MiioValetudoRobot) {
-            this.app.get("/gslb", (req, res) => {
-                const info = {
-                    "host_list": [
-                        {
-                            "ip": this.robot.embeddedDummycloudIp,
-                            "port": 8053
-                        }
-                    ],
-                    "enable": 1
-                };
-                const signature = require("crypto").createHmac("sha256", this.robot.cloudSecret)
-                    .update(JSON.stringify(info))
-                    .digest("base64");
-
-                res.status(200).send({
-                    "info": info,
-                    "timestamp": req.query["timestamp"],
-                    "sign": signature
-                });
-            });
+            this.app.get("/gslb", this.robot.handleHttpDnsRequest);
         }
-
 
         this.app.use((err, req, res, next) => {
             Logger.error("Unhandled WebServer Error", err);


### PR DESCRIPTION
ot is for UDP, ott is for TCP cloud connect which isn’t implemented by our dummycloud

This causes trouble, when miio_client thinks it has a TCP server in its list and even when unreachable they don’t seem to get removed again…
There are still quirks to the local development setup. Because of regular (/etc/hosts) DNS resolution fallback, miio_client actually manages sometimes (esp when restarting Valetudo locally) to establish a dummycloud connection with 127.0.0.1 and it then takes a while (~10 minutes in my early observations) to eventually retry the configured development host. We’ll probably need a config variant that disables the dummycloud entirely when only serving /gslb requests.

And in case anybody else is looking into debugging miio_client behavior. It logs to stdout by default which isn’t very useful in detached state, but it does take commandline arguments: `-l 4 -L /tmp/miio.log` will give you more detailed understanding of what’s going on.