### PR TITLE
consumables command fix for viaomi.v8

### DIFF
--- a/lib/robots/viomi/capabilities/ViomiConsumableMonitoringCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiConsumableMonitoringCapability.js
@@ -10,7 +10,7 @@ class ViomiConsumableMonitoringCapability extends ConsumableMonitoringCapability
      * @returns {Promise<Array<import("../../../entities/state/attributes/ConsumableStateAttribute")>>}
      */
     async getConsumables() {
-        const data = await this.robot.sendCommand("get_consumable");
+        const data = await this.robot.sendCommand("get_consumables");
         const rawConsumables = {
             mainBrush: data[0],
             sideBrush: data[1],


### PR DESCRIPTION
This fixes warning bellow for viomi.v8
[1970-01-25T21:23:18.712Z] [WARN] Token is okay, however we're unable to reach the vacuum { retries: 2260, method: 'get_consumable', args: [] }

as a result consumables left now printed on Consumables page
