### PR TITLE
Improve calculation of max elements in RoborockCombinedVirtualRestrictionsCapability

### DIFF
--- a/lib/robots/roborock/capabilities/RoborockCombinedVirtualRestrictionsCapability.js
+++ b/lib/robots/roborock/capabilities/RoborockCombinedVirtualRestrictionsCapability.js
@@ -43,7 +43,7 @@ class RoborockCombinedVirtualRestrictionsCapability extends CombinedVirtualRestr
         });
 
         if (roborockPayload.reduce((total, currentElem) => {
-            return total += currentElem.length - 1;
+            return total + currentElem.length - 1;
         }, 0) > 68) {
             throw new Error("too many forbidden markers to save!");
         }


### PR DESCRIPTION
While not *broken*, reassigning `total` was unnecessary and may cause confusion (Warning "The value assigned is never used").