### PR TITLE
Fix for pinch zoom bug in IOS / Safari

### DIFF
--- a/client/zone/js-modules/touch-handling.js
+++ b/client/zone/js-modules/touch-handling.js
@@ -227,6 +227,8 @@ export class TouchHandler {
         evt.stopPropagation();
         evt.preventDefault();
 
-        this.ongoingGesture = this.ongoingGesture.removePointer(changedTouches[0]);
+        changedTouches.forEach(e => {
+            this.ongoingGesture = this.ongoingGesture.removePointer(e);
+        });
     }
 }


### PR DESCRIPTION
After finally getting IOS to debug on a non-mac host, this PR fixes a pinch zoom issue with Safari on IOS where the pinch zoom becomes uncontrollable.  Symptom is after a pinch zoom event, a single finger drag results in the map zooming in / out instead of repositioning the map.
Root cause is with IOS where a single event can have multiple touches registered.  This is where a two finger pinch simultaneously has both fingers raised off the screen.  Original code only removed one of those touches, leaving an active touch which caused the issue.
Tested with IOS14 / Safari, Edge / Chrome W10 and Android Chrome and appears to fix issue with IOS and not break other devices.