### PR TITLE
Add Valetudo log to UI

### DIFF
--- a/client/services/api.service.js
+++ b/client/services/api.service.js
@@ -202,6 +202,18 @@ export class ApiService {
         return await this.fetch("GET", "api/v2/valetudo/version");
     }
 
+    static async getValetudoLogContent() {
+        return await this.fetch("GET", "api/v2/valetudo/log/content");
+    }
+
+    static async getValetudoLogLevel() {
+        return await this.fetch("GET", "api/v2/valetudo/log/level");
+    }
+
+    static async setValetudoLogLevel(level) {
+        await this.fetch("PUT", "api/v2/valetudo/log/level", {level: level});
+    }
+
     static async getRobot() {
         return await this.fetch("GET", "api/v2/robot");
     }

--- a/client/settings-info.html
+++ b/client/settings-info.html
@@ -81,9 +81,22 @@
                 ???
             </div>
         </ons-list-item>
+        <ons-list-item>
+            <div class="center" id="robot-log-controls">
+                <ons-button id="settings-info-valetudo-get-log" class="button-margin" onclick="getValetudoLog();">Refresh Log</ons-button>
+                <ons-button id="settings-info-valetudo-loglevel-button" class="button-margin" onclick="handleLoglevelButton()" disabled>Unknown log level</ons-button>
+            </div>
+        </ons-list-item>
+        <ons-list-item>
+            <label class="right" style="width:100%">
+                <ons-row>
+                    <ons-col>
+                        <textarea class="textarea" id="settings-info-valetudo-log" rows="20" readonly></textarea>
+                    </ons-col>
+                </ons-row>
+            </label>
+        </ons-list-item>
     </ons-list>
-
-
 
 
     <script>
@@ -96,7 +109,18 @@
 
         ons.getScriptPage().onShow = function() {
             updateSettingsInfoPage();
+            initValetudoLog();
         };
       }
     </script>
+    <style>
+        #robot-log-controls > ons-button {
+            margin: 5px;
+        }
+
+        #settings-info-valetudo-log {
+            font-family: monospace, sans-serif;
+            width: 100%;
+        }
+    </style>
 </ons-page>

--- a/docs/_pages/troubleshooting.md
+++ b/docs/_pages/troubleshooting.md
@@ -33,3 +33,12 @@ And check your Firewall-initscript /etc/rc.d/S51valetudo:
     
     for host in 203.0.113.1 203.0.113.5; do
     […]
+
+## Logging
+### Log Level
+
+Valetudo's log level can be set in the UI. It is not persisted across restarts. If you need to permanently set a log level, adjust it in the valetudo config file.
+
+### MQTT
+
+If you want to debug MQTT, you can set the `DEBUG` environment variable to `mqttjs*` (refer to the [MQTT.js README](https://github.com/mqttjs/MQTT.js#debug-logs)).

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -1,3 +1,4 @@
+const {EventEmitter} = require("events");
 const fs = require("fs");
 const util = require("util");
 
@@ -8,13 +9,19 @@ const LogFileOptions = Object.freeze({
 let LogLevel = 0;
 let LogFilename = "/dev/null";
 let LogFile = fs.createWriteStream(LogFilename, LogFileOptions);
+let LogEventEmitter = new EventEmitter();
 
 const LogLevels = Object.freeze({
-    "trace": -2,
-    "debug": -1,
-    "info": 0,
-    "warn": 1,
-    "error": 2
+    // eslint-disable-next-line no-console
+    "trace": {"level": -2, "callback": console.debug},
+    // eslint-disable-next-line no-console
+    "debug": {"level": -1, "callback": console.debug},
+    // eslint-disable-next-line no-console
+    "info": {"level": 0, "callback": console.info},
+    // eslint-disable-next-line no-console
+    "warn": {"level": 1, "callback": console.warn},
+    // eslint-disable-next-line no-console
+    "error": {"level": 2, "callback": console.error},
 });
 
 const BuildPrefix = (LogLevel) => {
@@ -52,18 +59,23 @@ class Logger {
         return LogFilename;
     }
 
+    static onLogMessage(listener) {
+        LogEventEmitter.on("LogMessage", listener);
+    }
+
     static log(level, ...args) {
-        if (LogLevel <= LogLevels[level]) {
+        if (LogLevel <= LogLevels[level]["level"]) {
             const logPrefix = BuildPrefix(level.toUpperCase());
-            // eslint-disable-next-line no-console
-            console.log(logPrefix, ...args);
-            LogFile.write([logPrefix, ...args].map(arg => {
+            LogLevels[level]["callback"](logPrefix, ...args);
+            const logLine = [logPrefix, ...args].map(arg => {
                 if (typeof arg === "string") {
                     return arg;
                 }
                 return util.inspect(arg);
-            }).join(" "));
+            }).join(" ");
+            LogFile.write(logLine);
             LogFile.write("\n");
+            LogEventEmitter.emit("LogMessage", logLine);
         }
     }
 

--- a/lib/Logger.js
+++ b/lib/Logger.js
@@ -1,4 +1,13 @@
+const fs = require("fs");
+const util = require("util");
+
+const LogFileOptions = Object.freeze({
+    flags: "as"
+});
+
 let LogLevel = 0;
+let LogFilename = "/dev/null";
+let LogFile = fs.createWriteStream(LogFilename, LogFileOptions);
 
 const LogLevels = Object.freeze({
     "trace": -2,
@@ -10,7 +19,7 @@ const LogLevels = Object.freeze({
 
 const BuildPrefix = (LogLevel) => {
     let timestamp = new Date().toISOString();
-    return "[" + timestamp + "] [" + LogLevel + "] ";
+    return "[" + timestamp + "] [" + LogLevel + "]";
 };
 
 class Logger {
@@ -20,71 +29,82 @@ class Logger {
     static get LogLevel() {
         return Object.keys(LogLevels).find(key => LogLevels[key] === LogLevel);
     }
+    static get LogLevels() {
+        return LogLevels;
+    }
     static set LogLevel(value) {
         if (LogLevels[value] === undefined) {
             throw "invalid log level '" + value + "', valid are '" + Object.keys(LogLevels).join("','") + "'";
         }
         LogLevel = LogLevels[value];
     }
+    static set LogFile(filename) {
+        if (LogFilename === filename) {
+            return;
+        }
+        if (LogFile) {
+            LogFile.close();
+        }
+        LogFilename = filename;
+        LogFile = fs.createWriteStream(LogFilename, LogFileOptions);
+    }
+    static get LogFile() {
+        return LogFilename;
+    }
+
+    static log(level, ...args) {
+        if (LogLevel <= LogLevels[level]) {
+            const logPrefix = BuildPrefix(level.toUpperCase());
+            // eslint-disable-next-line no-console
+            console.log(logPrefix, ...args);
+            LogFile.write([logPrefix, ...args].map(arg => {
+                if (typeof arg === "string") {
+                    return arg;
+                }
+                return util.inspect(arg);
+            }).join(" "));
+            LogFile.write("\n");
+        }
+    }
 
     /**
      * @see console.trace
-     * @param {string} message
      * @param  {...any} args
      */
-    static trace(message, ...args) {
-        if (LogLevel <= LogLevels.trace) {
-            // eslint-disable-next-line no-console
-            console.debug(BuildPrefix("TRACE") + message, ...args);
-        }
+    static trace(...args) {
+        Logger.log("trace", ...args);
     }
 
     /**
      * @see console.debug
-     * @param {string} message
      * @param  {...any} args
      */
-    static debug(message, ...args) {
-        if (LogLevel <= LogLevels.debug) {
-            // eslint-disable-next-line no-console
-            console.debug(BuildPrefix("DEBUG") + message, ...args);
-        }
+    static debug(...args) {
+        Logger.log("debug", ...args);
     }
 
     /**
      * @see console.info
-     * @param {string} message
      * @param  {...any} args
      */
-    static info(message, ...args) {
-        if (LogLevel <= LogLevels.info) {
-            // eslint-disable-next-line no-console
-            console.info(BuildPrefix("INFO") + message, ...args);
-        }
+    static info(...args) {
+        Logger.log("info", ...args);
     }
 
     /**
      * @see console.warn
-     * @param {string} message
      * @param  {...any} args
      */
-    static warn(message, ...args) {
-        if (LogLevel <= LogLevels.warn) {
-            // eslint-disable-next-line no-console
-            console.warn(BuildPrefix("WARN") + message, ...args);
-        }
+    static warn(...args) {
+        Logger.log("warn", ...args);
     }
 
     /**
      * @see console.error
-     * @param {string} message
      * @param  {...any} args
      */
-    static error(message, ...args) {
-        if (LogLevel <= LogLevels.error) {
-            // eslint-disable-next-line no-console
-            console.error(BuildPrefix("ERROR") + message, ...args);
-        }
+    static error( ...args) {
+        Logger.log("error", ...args);
     }
 }
 

--- a/lib/Valetudo.js
+++ b/lib/Valetudo.js
@@ -1,4 +1,6 @@
 const v8 = require("v8");
+const path = require("path");
+const os = require("os");
 const NTPClient = require("./NTPClient");
 const Webserver = require("./webserver/WebServer");
 const MqttClient = require("./mqtt/MqttClient");
@@ -14,7 +16,9 @@ class Valetudo {
         this.config = new Configuration();
 
         try {
-            Logger.LogLevel = this.config.get("logLevel");
+            const logConfig = this.config.get("logging");
+            Logger.LogLevel = logConfig.level;
+            Logger.LogFile = logConfig.file || path.join(os.tmpdir(), "valetudo.log");
         } catch (e) {
             Logger.error("Initialising Logger: " + e);
         }

--- a/lib/Valetudo.js
+++ b/lib/Valetudo.js
@@ -16,9 +16,8 @@ class Valetudo {
         this.config = new Configuration();
 
         try {
-            const logConfig = this.config.get("logging");
-            Logger.LogLevel = logConfig.level;
-            Logger.LogFile = logConfig.file || path.join(os.tmpdir(), "valetudo.log");
+            Logger.LogLevel = this.config.get("logLevel");
+            Logger.LogFile = process.env.VALETUDO_LOG_PATH || path.join(os.tmpdir(), "valetudo.log");
         } catch (e) {
             Logger.error("Initialising Logger: " + e);
         }

--- a/lib/mqtt/MqttAutoConfManager.js
+++ b/lib/mqtt/MqttAutoConfManager.js
@@ -37,7 +37,9 @@ class MqttAutoConfManager { //TODO: does this thing even make sense?
 
             custom_command: this.topicPrefix + "/" + this.identifier + "/custom_command", //TODO: maybe merge this with the regular command topic?
 
-            map_data: this.topicPrefix + "/" + this.identifier + "/map_data"
+            map_data: this.topicPrefix + "/" + this.identifier + "/map_data",
+
+            log_message: this.topicPrefix + "/" + this.identifier + "/log_message"
         };
 
         this.internalAutoconfData = [

--- a/lib/mqtt/MqttClient.js
+++ b/lib/mqtt/MqttClient.js
@@ -52,6 +52,9 @@ class MqttClient {
             }
         });
 
+        Logger.onLogMessage((line) => {
+            this.publish(this.autoConfManager.topics.log_message, line);
+        });
 
         this.robot.onStateUpdated(() => {
             this.updateStatusTopic();

--- a/lib/mqtt/MqttClient.js
+++ b/lib/mqtt/MqttClient.js
@@ -52,9 +52,10 @@ class MqttClient {
             }
         });
 
-        Logger.onLogMessage((line) => {
-            this.publish(this.autoConfManager.topics.log_message, line);
-        });
+        // TODO: To be evaluated due to secrets in the log
+        // Logger.onLogMessage((line) => {
+        //     this.publish(this.autoConfManager.topics.log_message, line);
+        // });
 
         this.robot.onStateUpdated(() => {
             this.updateStatusTopic();

--- a/lib/res/default_config.json
+++ b/lib/res/default_config.json
@@ -42,10 +42,7 @@
         "timeout": 10000
     },
     "allowSSHKeyUpload": true,
-    "logging": {
-        "level": "info",
-        "file": "/dev/null"
-    },
+    "logLevel": "info",
     "debug": {
         "memoryStatInterval" : false,
         "enableRawCommandCapability": false

--- a/lib/res/default_config.json
+++ b/lib/res/default_config.json
@@ -42,7 +42,10 @@
         "timeout": 10000
     },
     "allowSSHKeyUpload": true,
-    "logLevel": "info",
+    "logging": {
+        "level": "info",
+        "file": "/dev/null"
+    },
     "debug": {
         "memoryStatInterval" : false,
         "enableRawCommandCapability": false

--- a/lib/webserver/ValetudoRouter.js
+++ b/lib/webserver/ValetudoRouter.js
@@ -43,11 +43,6 @@ class ValetudoRouter {
         this.router.put("/log/level", (req, res) => {
             if (req.body && req.body.level && typeof req.body.level === "string") {
                 Logger.LogLevel = req.body.level;
-                const loggingConfig = this.config.get("logging");
-                this.config.set("logging", {
-                    ...loggingConfig,
-                    level: req.body.level,
-                });
             }
             res.sendStatus(202);
         });

--- a/lib/webserver/ValetudoRouter.js
+++ b/lib/webserver/ValetudoRouter.js
@@ -2,7 +2,7 @@ const express = require("express");
 const fs = require("fs");
 
 const Tools = require("../Tools");
-
+const Logger = require("../Logger");
 
 class ValetudoRouter {
     /**
@@ -27,6 +27,29 @@ class ValetudoRouter {
             res.json({
                 release: Tools.GET_VALETUDO_VERSION()
             });
+        });
+
+        this.router.get("/log/content", (req, res) => {
+            res.sendFile(Logger.LogFile);
+        });
+
+        this.router.get("/log/level", (req, res) => {
+            res.json({
+                current: Logger.LogLevel,
+                presets: Object.keys(Logger.LogLevels)
+            });
+        });
+
+        this.router.put("/log/level", (req, res) => {
+            if (req.body && req.body.level && typeof req.body.level === "string") {
+                Logger.LogLevel = req.body.level;
+                const loggingConfig = this.config.get("logging");
+                this.config.set("logging", {
+                    ...loggingConfig,
+                    level: req.body.level,
+                });
+            }
+            res.sendStatus(202);
         });
 
         this.router.get("/config/interfaces/mqtt", (req, res) => {


### PR DESCRIPTION
We talked about this :)

This adds support for getting the Log in the UI and setting the log level:

![image](https://user-images.githubusercontent.com/8963459/107983432-0d2a0f00-6fc6-11eb-945f-929efcb71dfc.png)

I am not sure about the default location of the logfile: `path.join(os.tmpdir(), "valetudo.log");` - A better location might be in `/var/log/...`? Maybe depends on the robot. A default location of `/dev/null` would also work, though then the UI Log would not work ("Empty logfile" message).

Logging is directed to both that file and `console.log`. Not sure about removing `console.log`.