### PR TITLE
Do not cache API responses

### DIFF
--- a/client/services/api.service.js
+++ b/client/services/api.service.js
@@ -12,7 +12,8 @@ export class ApiService {
             headers: {
                 "Content-Type": "application/json"
             },
-            body: JSON.stringify(body)
+            body: JSON.stringify(body),
+            cache: "no-store"
         });
         if (!response.ok) {
             throw Error(await response.text());

--- a/client/settings-info.js
+++ b/client/settings-info.js
@@ -85,6 +85,9 @@ async function getValetudoLog() {
         var valetudoLogRes = await ApiService.getValetudoLogContent();
         logTextArea.value = valetudoLogRes || "Empty Logfile";
         logTextArea.scrollTop = logTextArea.scrollHeight;
+    } catch (err) {
+        ons.notification.toast(err.message,
+            {buttonLabel: "Dismiss", timeout: window.fn.toastErrorTimeout});
     } finally {
         loadingBarSettingsInfo.removeAttribute("indeterminate");
     }


### PR DESCRIPTION
Sometimes the browser cache seems to not return even the cached responses. As the payload of API calls is fairly small, turning off caching should not be a performance issue.
