### PR TITLE
Add voice pack managemenet capability

### DIFF
--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -1,0 +1,88 @@
+const NotImplementedError = require("../NotImplementedError");
+const Capability = require("./Capability");
+
+class VoicePackManagementCapability extends Capability {
+    /**
+     * This method must return voice packs that are available on the device without requiring any downloads, or voice
+     * packs that the vacuum can download and apply without additional user input.
+     * For example, the Viomi has English and Chinese pre-installed, other voice packs require to be downloaded.
+     * Therefore it should only return English and Chinese at any time, even if a downloaded voice pack is available,
+     * Other vacuums which can talk to the cloud server without additional intervention, or whose capability can perform
+     * the same, may list the available voice packs here.
+     *
+     * @abstract
+     * @returns {Promise<string[]>}
+     */
+    async getAvailableStockVoicePacks() {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * This method can be used to enable a local, pre-installed stock voice pack, or instruct the vacuum to download one
+     * of its stock voice packs.
+     *
+     * @abstract
+     * @returns {Promise<void>}
+     */
+    async enableStockVoicePack() {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * Returns the current applied voice pack language.
+     *
+     * @abstract
+     * @returns {Promise<void>}
+     */
+    async getCurrentVoiceLanguage() {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * This method should return whether the `downloadCustomVoicePack` functionality is supported by the vacuum.
+     *
+     * @abstract
+     * @returns {Promise<boolean>}
+     */
+    async canDownloadCustomVoicePack() {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * This method should instruct the vacuum to download a voice pack from `presignedUrl`.
+     * The actual specifications of what exactly is hosted behind presignedUrl depend on the specific vacuum model..
+     *
+     * @abstract
+     * @param {string} language
+     * @param {string} presignedUrl
+     * @returns {Promise<void>}
+     */
+    async downloadCustomVoicePack(language, presignedUrl) {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * This method should return the progress of the current voice pack operation.
+     * This could describe one of the following:
+     * - Progress of custom or stock (but not available locally) voice pack download
+     * - Progress of unpacking of in-device voice pack
+     * The progress should be returned as a percentage, null if the operation has completed or no operation in progress.
+     *
+     * @abstract
+     * @returns {Promise<[number]>}
+     */
+    async getVoicePackOperationProgress() {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * @returns {string}
+     */
+    getType() {
+        return VoicePackManagementCapability.TYPE;
+    }
+}
+
+VoicePackManagementCapability.TYPE = "VoicePackManagementCapability";
+
+module.exports = VoicePackManagementCapability;

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -31,7 +31,7 @@ class VoicePackManagementCapability extends Capability {
      * Returns the current applied voice pack language.
      *
      * @abstract
-     * @returns {Promise<void>}
+     * @returns {Promise<string>}
      */
     async getCurrentVoiceLanguage() {
         throw new NotImplementedError();

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -42,11 +42,10 @@ class VoicePackManagementCapability extends Capability {
     /**
      * This method should return whether the `downloadCustomVoicePack` functionality is supported by the vacuum.
      *
-     * @abstract
      * @returns {Promise<boolean>}
      */
     async canDownloadCustomVoicePack() {
-        throw new NotImplementedError();
+        return false;
     }
 
     /**
@@ -54,14 +53,13 @@ class VoicePackManagementCapability extends Capability {
      * The actual specifications of what exactly is hosted behind presignedUrl depend on the specific vacuum model.
      * The same goes for the hash, the user should provide a hash or signature as expected by the vacuum.
      *
-     * @abstract
      * @param {string} language
      * @param {string} presignedUrl
      * @param {string} hash
      * @returns {Promise<void>}
      */
     async downloadCustomVoicePack(language, presignedUrl, hash) {
-        throw new NotImplementedError();
+        return null;
     }
 
     /**

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -22,9 +22,10 @@ class VoicePackManagementCapability extends Capability {
      * of its stock voice packs.
      *
      * @abstract
+     * @param {string} language
      * @returns {Promise<void>}
      */
-    async enableStockVoicePack() {
+    async enableStockVoicePack(language) {
         throw new NotImplementedError();
     }
 

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -31,10 +31,11 @@ class VoicePackManagementCapability extends Capability {
     /**
      * This method should return the status of the current voice pack operation, if one is ongoing.
      *
+     * @abstract
      * @returns {Promise<import("../../entities/core/ValetudoVoicePackOperationStatus")>}
      */
     async getVoicePackOperationStatus() {
-        return null;
+        throw new NotImplementedError();
     }
 
     /**

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -19,7 +19,7 @@ class VoicePackManagementCapability extends Capability {
      *
      * @abstract
      * @param {object} options
-     * @param {string} options.presignedUrl
+     * @param {string} options.url
      * @param {string} [options.language]
      * @param {string} [options.hash]
      * @returns {Promise<void>}

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -50,14 +50,16 @@ class VoicePackManagementCapability extends Capability {
 
     /**
      * This method should instruct the vacuum to download a voice pack from `presignedUrl`.
-     * The actual specifications of what exactly is hosted behind presignedUrl depend on the specific vacuum model..
+     * The actual specifications of what exactly is hosted behind presignedUrl depend on the specific vacuum model.
+     * The same goes for the hash, the user should provide a hash or signature as expected by the vacuum.
      *
      * @abstract
      * @param {string} language
      * @param {string} presignedUrl
+     * @param {string} hash
      * @returns {Promise<void>}
      */
-    async downloadCustomVoicePack(language, presignedUrl) {
+    async downloadCustomVoicePack(language, presignedUrl, hash) {
         throw new NotImplementedError();
     }
 

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -29,12 +29,11 @@ class VoicePackManagementCapability extends Capability {
     }
 
     /**
-     * This method should return the progress of the current voice pack operation.
-     * The progress should be returned as a percentage, null if the operation has completed or no operation in progress.
+     * This method should return the status of the current voice pack operation, if one is ongoing.
      *
-     * @returns {Promise<[number]>}
+     * @returns {Promise<import("../../entities/core/ValetudoVoicePackOperationStatus")>}
      */
-    async getVoicePackOperationProgress() {
+    async getVoicePackOperationStatus() {
         return null;
     }
 

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -53,12 +53,13 @@ class VoicePackManagementCapability extends Capability {
      * The actual specifications of what exactly is hosted behind presignedUrl depend on the specific vacuum model.
      * The same goes for the hash, the user should provide a hash or signature as expected by the vacuum.
      *
-     * @param {string} language
-     * @param {string} presignedUrl
-     * @param {string} hash
+     * @param {object} options
+     * @param {string} options.presignedUrl
+     * @param {string} [options.language]
+     * @param {string} [options.hash]
      * @returns {Promise<void>}
      */
-    async downloadCustomVoicePack(language, presignedUrl, hash) {
+    async downloadCustomVoicePack(options) {
         return null;
     }
 

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -3,31 +3,6 @@ const Capability = require("./Capability");
 
 class VoicePackManagementCapability extends Capability {
     /**
-     * This method must return voice packs that are available on the device without requiring any downloads, or voice
-     * packs that the vacuum can download and apply without additional user input.
-     * For example, the Viomi has English and Chinese pre-installed, other voice packs require to be downloaded.
-     * Therefore it should only return English and Chinese at any time, even if a downloaded voice pack is available,
-     * Other vacuums which can talk to the cloud server without additional intervention, or whose capability can perform
-     * the same, may list the available voice packs here.
-     *
-     * @returns {Promise<string[]>}
-     */
-    async getAvailableStockVoicePacks() {
-        return [];
-    }
-
-    /**
-     * This method can be used to enable a local, pre-installed stock voice pack, or instruct the vacuum to download one
-     * of its stock voice packs.
-     *
-     * @param {string} language
-     * @returns {Promise<void>}
-     */
-    async enableStockVoicePack(language) {
-        throw new Error("Not supported");
-    }
-
-    /**
      * Returns the current applied voice pack language.
      *
      * @abstract
@@ -38,34 +13,23 @@ class VoicePackManagementCapability extends Capability {
     }
 
     /**
-     * This method should return whether the `downloadCustomVoicePack` functionality is supported by the vacuum.
-     *
-     * @returns {Promise<boolean>}
-     */
-    async canDownloadCustomVoicePack() {
-        return false;
-    }
-
-    /**
      * This method should instruct the vacuum to download a voice pack from `presignedUrl`.
      * The actual specifications of what exactly is hosted behind presignedUrl depend on the specific vacuum model.
      * The same goes for the hash, the user should provide a hash or signature as expected by the vacuum.
      *
+     * @abstract
      * @param {object} options
      * @param {string} options.presignedUrl
      * @param {string} [options.language]
      * @param {string} [options.hash]
      * @returns {Promise<void>}
      */
-    async downloadCustomVoicePack(options) {
-        throw new Error("Not supported");
+    async downloadVoicePack(options) {
+        throw new NotImplementedError();
     }
 
     /**
      * This method should return the progress of the current voice pack operation.
-     * This could describe one of the following:
-     * - Progress of custom or stock (but not available locally) voice pack download
-     * - Progress of unpacking of in-device voice pack
      * The progress should be returned as a percentage, null if the operation has completed or no operation in progress.
      *
      * @returns {Promise<[number]>}

--- a/lib/core/capabilities/VoicePackManagementCapability.js
+++ b/lib/core/capabilities/VoicePackManagementCapability.js
@@ -10,23 +10,21 @@ class VoicePackManagementCapability extends Capability {
      * Other vacuums which can talk to the cloud server without additional intervention, or whose capability can perform
      * the same, may list the available voice packs here.
      *
-     * @abstract
      * @returns {Promise<string[]>}
      */
     async getAvailableStockVoicePacks() {
-        throw new NotImplementedError();
+        return [];
     }
 
     /**
      * This method can be used to enable a local, pre-installed stock voice pack, or instruct the vacuum to download one
      * of its stock voice packs.
      *
-     * @abstract
      * @param {string} language
      * @returns {Promise<void>}
      */
     async enableStockVoicePack(language) {
-        throw new NotImplementedError();
+        throw new Error("Not supported");
     }
 
     /**
@@ -60,7 +58,7 @@ class VoicePackManagementCapability extends Capability {
      * @returns {Promise<void>}
      */
     async downloadCustomVoicePack(options) {
-        return null;
+        throw new Error("Not supported");
     }
 
     /**
@@ -70,11 +68,10 @@ class VoicePackManagementCapability extends Capability {
      * - Progress of unpacking of in-device voice pack
      * The progress should be returned as a percentage, null if the operation has completed or no operation in progress.
      *
-     * @abstract
      * @returns {Promise<[number]>}
      */
     async getVoicePackOperationProgress() {
-        throw new NotImplementedError();
+        return null;
     }
 
     /**

--- a/lib/core/capabilities/index.js
+++ b/lib/core/capabilities/index.js
@@ -20,5 +20,6 @@ module.exports = {
     RawCommandCapability: require("./RawCommandCapability"),
     DoNotDisturbCapability: require("./DoNotDisturbCapability"),
     CarpetModeControlCapability: require("./CarpetModeControlCapability"),
-    SpeakerTestCapability: require("./SpeakerTestCapability")
+    SpeakerTestCapability: require("./SpeakerTestCapability"),
+    VoicePackManagementCapability: require("./VoicePackManagementCapability"),
 };

--- a/lib/entities/core/ValetudoVoicePackOperationStatus.js
+++ b/lib/entities/core/ValetudoVoicePackOperationStatus.js
@@ -1,0 +1,39 @@
+const SerializableEntity = require("../SerializableEntity");
+
+/**
+ * @class ValetudoVoicePackOperationStatus
+ * @property {ValetudoVoicePackOperationStatusType} type
+ * @property {number} [progress]
+ */
+class ValetudoVoicePackOperationStatus extends SerializableEntity {
+    /**
+     * This entity represents the status of a voice pack operation.
+     *
+     * @param {object} options
+     * @param {ValetudoVoicePackOperationStatusType} options.type
+     * @param {number} [options.progress] represents the download or installation progress in the range 0-100
+     * @param {object} [options.metaData]
+     * @class
+     */
+    constructor(options) {
+        super(options);
+
+        this.type = options.type;
+        this.progress = options.progress;
+    }
+}
+
+
+/**
+ *  @typedef {string} ValetudoVoicePackOperationStatusType
+ *  @enum {string}
+ *
+ */
+ValetudoVoicePackOperationStatus.TYPE = Object.freeze({
+    IDLE: "idle",
+    DOWNLOADING: "downloading",
+    INSTALLING: "installing",
+});
+
+
+module.exports = ValetudoVoicePackOperationStatus;

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -78,6 +78,10 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
         this.registerCapability(new capabilities.ViomiZoneCleaningCapability({
             robot: this
         }));
+
+        this.registerCapability(new capabilities.ViomiVoicePackManagementCapability({
+            robot: this
+        }));
     }
 
     setEmbeddedParameters() {

--- a/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
@@ -2,31 +2,6 @@ const VoicePackManagementCapability = require("../../../core/capabilities/VoiceP
 
 class ViomiVoicePackManagementCapability extends VoicePackManagementCapability {
     /**
-     * This method must return voice packs that are available on the device without requiring any downloads, or voice
-     * packs that the vacuum can download and apply without additional user input.
-     * For example, the Viomi has English and Chinese pre-installed, other voice packs require to be downloaded.
-     * Therefore it should only return English and Chinese at any time, even if a downloaded voice pack is available,
-     * Other vacuums which can talk to the cloud server without additional intervention, or whose capability can perform
-     * the same, may list the available voice packs here.
-     *
-     * @returns {Promise<string[]>}
-     */
-    async getAvailableStockVoicePacks() {
-        return ["en", "zh"];
-    }
-
-    /**
-     * This method can be used to enable a local, pre-installed stock voice pack, or instruct the vacuum to download one
-     * of its stock voice packs.
-     *
-     * @param {string} language
-     * @returns {Promise<void>}
-     */
-    async enableStockVoicePack(language) {
-        await this.robot.sendCommand("download_voice", [language, "local", "local"]);
-    }
-
-    /**
      * Returns the current applied voice pack language.
      *
      * @abstract
@@ -40,15 +15,6 @@ class ViomiVoicePackManagementCapability extends VoicePackManagementCapability {
     }
 
     /**
-     * This method should return whether the `downloadCustomVoicePack` functionality is supported by the vacuum.
-     *
-     * @returns {Promise<boolean>}
-     */
-    async canDownloadCustomVoicePack() {
-        return true;
-    }
-
-    /**
      * This method should instruct the vacuum to download a voice pack from `presignedUrl`.
      * The actual specifications of what exactly is hosted behind presignedUrl depend on the specific vacuum model.
      * The same goes for the hash, the user should provide a hash or signature as expected by the vacuum.
@@ -59,7 +25,7 @@ class ViomiVoicePackManagementCapability extends VoicePackManagementCapability {
      * @param {string} [options.hash]
      * @returns {Promise<void>}
      */
-    async downloadCustomVoicePack(options) {
+    async downloadVoicePack(options) {
         let args = ["it", options.presignedUrl, "viomi doesn't even bother blabla"];
         if (options.language) {
             args[0] = options.language;

--- a/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
@@ -1,4 +1,5 @@
 const VoicePackManagementCapability = require("../../../core/capabilities/VoicePackManagementCapability");
+const ValetudoVoicePackOperationStatus = require("../../../entities/core/ValetudoVoicePackOperationStatus");
 
 class ViomiVoicePackManagementCapability extends VoicePackManagementCapability {
     /**
@@ -38,24 +39,32 @@ class ViomiVoicePackManagementCapability extends VoicePackManagementCapability {
     }
 
     /**
-     * This method should return the progress of the current voice pack operation.
-     * This could describe one of the following:
-     * - Progress of custom or stock (but not available locally) voice pack download
-     * - Progress of unpacking of in-device voice pack
-     * The progress should be returned as a percentage, null if the operation has completed or no operation in progress.
+     * This method should return the status of the current voice pack operation, if one is ongoing.
      *
-     * @returns {Promise<[number]>}
+     * @returns {Promise<ValetudoVoicePackOperationStatus>}
      */
-    async getVoicePackOperationProgress() {
+    async getVoicePackOperationStatus() {
+        let statusOptions = {
+            type: ValetudoVoicePackOperationStatus.TYPE.IDLE,
+            progress: undefined,
+        };
         const res = await this.robot.sendCommand("get_downloadstatus", []);
-        // @ts-ignore
+
         // noinspection JSUnresolvedVariable
-        if (res.targetVoice === "") {
-            return null;
+        if (res.targetVoice !== "") {
+            // noinspection JSUnresolvedVariable
+            if (res.progress === 100 || res.targetVoice === "en" || res.targetVoice === "zh") {
+                // en and zh are built-in and won't be downloaded, even if a URL is provided.
+                statusOptions.type = ValetudoVoicePackOperationStatus.TYPE.INSTALLING;
+            } else {
+                statusOptions.type = ValetudoVoicePackOperationStatus.TYPE.DOWNLOADING;
+            }
+            // noinspection JSUnresolvedVariable
+            statusOptions.progress = res.progress;
         }
-        // @ts-ignore
+
         // noinspection JSUnresolvedVariable
-        return res.progress;
+        return new ValetudoVoicePackOperationStatus(statusOptions);
     }
 }
 

--- a/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
@@ -21,13 +21,13 @@ class ViomiVoicePackManagementCapability extends VoicePackManagementCapability {
      * The same goes for the hash, the user should provide a hash or signature as expected by the vacuum.
      *
      * @param {object} options
-     * @param {string} options.presignedUrl
+     * @param {string} options.url
      * @param {string} [options.language]
      * @param {string} [options.hash]
      * @returns {Promise<void>}
      */
     async downloadVoicePack(options) {
-        let args = ["it", options.presignedUrl, "viomi doesn't even bother blabla"];
+        let args = ["it", options.url, "viomi doesn't even bother blabla"];
         if (options.language) {
             args[0] = options.language;
         }

--- a/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
@@ -84,6 +84,11 @@ class ViomiVoicePackManagementCapability extends VoicePackManagementCapability {
         const res = await this.robot.sendCommand("get_downloadstatus", []);
         // @ts-ignore
         // noinspection JSUnresolvedVariable
+        if (res.targetVoice === "") {
+            return null;
+        }
+        // @ts-ignore
+        // noinspection JSUnresolvedVariable
         return res.progress;
     }
 }

--- a/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiVoicePackManagementCapability.js
@@ -1,0 +1,91 @@
+const VoicePackManagementCapability = require("../../../core/capabilities/VoicePackManagementCapability");
+
+class ViomiVoicePackManagementCapability extends VoicePackManagementCapability {
+    /**
+     * This method must return voice packs that are available on the device without requiring any downloads, or voice
+     * packs that the vacuum can download and apply without additional user input.
+     * For example, the Viomi has English and Chinese pre-installed, other voice packs require to be downloaded.
+     * Therefore it should only return English and Chinese at any time, even if a downloaded voice pack is available,
+     * Other vacuums which can talk to the cloud server without additional intervention, or whose capability can perform
+     * the same, may list the available voice packs here.
+     *
+     * @returns {Promise<string[]>}
+     */
+    async getAvailableStockVoicePacks() {
+        return ["en", "zh"];
+    }
+
+    /**
+     * This method can be used to enable a local, pre-installed stock voice pack, or instruct the vacuum to download one
+     * of its stock voice packs.
+     *
+     * @param {string} language
+     * @returns {Promise<void>}
+     */
+    async enableStockVoicePack(language) {
+        await this.robot.sendCommand("download_voice", [language, "local", "local"]);
+    }
+
+    /**
+     * Returns the current applied voice pack language.
+     *
+     * @abstract
+     * @returns {Promise<string>}
+     */
+    async getCurrentVoiceLanguage() {
+        const res = await this.robot.sendCommand("get_downloadstatus", []);
+        // @ts-ignore
+        // noinspection JSUnresolvedVariable
+        return res.curVoice;
+    }
+
+    /**
+     * This method should return whether the `downloadCustomVoicePack` functionality is supported by the vacuum.
+     *
+     * @returns {Promise<boolean>}
+     */
+    async canDownloadCustomVoicePack() {
+        return true;
+    }
+
+    /**
+     * This method should instruct the vacuum to download a voice pack from `presignedUrl`.
+     * The actual specifications of what exactly is hosted behind presignedUrl depend on the specific vacuum model.
+     * The same goes for the hash, the user should provide a hash or signature as expected by the vacuum.
+     *
+     * @param {object} options
+     * @param {string} options.presignedUrl
+     * @param {string} [options.language]
+     * @param {string} [options.hash]
+     * @returns {Promise<void>}
+     */
+    async downloadCustomVoicePack(options) {
+        let args = ["it", options.presignedUrl, "viomi doesn't even bother blabla"];
+        if (options.language) {
+            args[0] = options.language;
+        }
+        if (options.hash) {
+            args[2] = options.hash;
+        }
+
+        await this.robot.sendCommand("download_voice", args);
+    }
+
+    /**
+     * This method should return the progress of the current voice pack operation.
+     * This could describe one of the following:
+     * - Progress of custom or stock (but not available locally) voice pack download
+     * - Progress of unpacking of in-device voice pack
+     * The progress should be returned as a percentage, null if the operation has completed or no operation in progress.
+     *
+     * @returns {Promise<[number]>}
+     */
+    async getVoicePackOperationProgress() {
+        const res = await this.robot.sendCommand("get_downloadstatus", []);
+        // @ts-ignore
+        // noinspection JSUnresolvedVariable
+        return res.progress;
+    }
+}
+
+module.exports = ViomiVoicePackManagementCapability;

--- a/lib/robots/viomi/capabilities/index.js
+++ b/lib/robots/viomi/capabilities/index.js
@@ -8,5 +8,6 @@ module.exports = {
     ViomiConsumableMonitoringCapability: require("./ViomiConsumableMonitoringCapability"),
     ViomiZoneCleaningCapability: require("./ViomiZoneCleaningCapability"),
     ViomiPersistentMapControlCapability: require("./ViomiPersistentMapControlCapability"),
+    ViomiVoicePackManagementCapability: require("./ViomiVoicePackManagementCapability"),
     ViomiCombinedVirtualRestrictionsCapability: require("./ViomiCombinedVirtualRestrictionsCapability")
 };

--- a/lib/webserver/CapabilitiesRouter.js
+++ b/lib/webserver/CapabilitiesRouter.js
@@ -72,7 +72,8 @@ const CAPABILITY_TYPE_TO_ROUTER_MAPPING = {
     [capabilities.MapSegmentationCapability.TYPE]: capabilityRouters.MapSegmentationCapabilityRouter,
     [capabilities.DoNotDisturbCapability.TYPE]: capabilityRouters.DoNotDisturbCapabilityRouter,
     [capabilities.CarpetModeControlCapability.TYPE]: capabilityRouters.CarpetModeControlCapabilityRouter,
-    [capabilities.SpeakerTestCapability.TYPE]: capabilityRouters.SpeakerTestCapabilityRouter
+    [capabilities.SpeakerTestCapability.TYPE]: capabilityRouters.SpeakerTestCapabilityRouter,
+    [capabilities.VoicePackManagementCapability.TYPE]: capabilityRouters.VoicePackManagementCapabilityRouter,
 };
 
 module.exports = CapabilitiesRouter;

--- a/lib/webserver/capabilityRouters/VoicePackManagementCapabilityRouter.js
+++ b/lib/webserver/capabilityRouters/VoicePackManagementCapabilityRouter.js
@@ -1,0 +1,57 @@
+const Logger = require("../../Logger");
+const CapabilityRouter = require("./CapabilityRouter");
+
+class VoicePackManagementCapabilityRouter extends CapabilityRouter {
+
+    initRoutes() {
+        this.router.get("/", async (req, res) => {
+            res.json({
+                "currentLanguage": await this.capability.getCurrentVoiceLanguage(),
+                "operationProgress": await this.capability.getVoicePackOperationProgress()
+            });
+        });
+
+        this.router.get("/stockPack", async (req, res) => {
+            res.json(await this.capability.getAvailableStockVoicePacks());
+        });
+
+        this.router.put("/stockPack", async (req, res) => {
+            if (req.body && req.body.action === "enable" && req.body.language) {
+                try {
+                    await this.capability.enableStockVoicePack(req.body.language);
+                    res.sendStatus(200);
+                } catch (e) {
+                    Logger.warn("Unable to set stock language pack", e);
+                    res.status(500).json(e.message);
+                }
+            } else {
+                res.status(400).send("Invalid request");
+            }
+        });
+
+        this.router.get("/customPack", async (req, res) => {
+            res.json({
+                "supported": await this.capability.canDownloadCustomVoicePack()
+            });
+        });
+
+        this.router.put("/customPack", async (req, res) => {
+            if (req.body && req.body.action === "download" && req.body.presignedUrl) {
+                try {
+                    await this.capability.downloadCustomVoicePack({
+                        presignedUrl: req.body.presignedUrl,
+                        language: req.body.language,
+                        hash: req.body.hash
+                    });
+                    res.sendStatus(200);
+                } catch (e) {
+                    res.status(500).send(e.message);
+                }
+            } else {
+                res.status(400).send("Invalid request");
+            }
+        });
+    }
+}
+
+module.exports = VoicePackManagementCapabilityRouter;

--- a/lib/webserver/capabilityRouters/VoicePackManagementCapabilityRouter.js
+++ b/lib/webserver/capabilityRouters/VoicePackManagementCapabilityRouter.js
@@ -1,4 +1,3 @@
-const Logger = require("../../Logger");
 const CapabilityRouter = require("./CapabilityRouter");
 
 class VoicePackManagementCapabilityRouter extends CapabilityRouter {
@@ -11,34 +10,10 @@ class VoicePackManagementCapabilityRouter extends CapabilityRouter {
             });
         });
 
-        this.router.get("/stockPack", async (req, res) => {
-            res.json(await this.capability.getAvailableStockVoicePacks());
-        });
-
-        this.router.put("/stockPack", async (req, res) => {
-            if (req.body && req.body.action === "enable" && req.body.language) {
-                try {
-                    await this.capability.enableStockVoicePack(req.body.language);
-                    res.sendStatus(200);
-                } catch (e) {
-                    Logger.warn("Unable to set stock language pack", e);
-                    res.status(500).json(e.message);
-                }
-            } else {
-                res.status(400).send("Invalid request");
-            }
-        });
-
-        this.router.get("/customPack", async (req, res) => {
-            res.json({
-                "supported": await this.capability.canDownloadCustomVoicePack()
-            });
-        });
-
-        this.router.put("/customPack", async (req, res) => {
+        this.router.put("/", async (req, res) => {
             if (req.body && req.body.action === "download" && req.body.presignedUrl) {
                 try {
-                    await this.capability.downloadCustomVoicePack({
+                    await this.capability.downloadVoicePack({
                         presignedUrl: req.body.presignedUrl,
                         language: req.body.language,
                         hash: req.body.hash

--- a/lib/webserver/capabilityRouters/VoicePackManagementCapabilityRouter.js
+++ b/lib/webserver/capabilityRouters/VoicePackManagementCapabilityRouter.js
@@ -11,10 +11,10 @@ class VoicePackManagementCapabilityRouter extends CapabilityRouter {
         });
 
         this.router.put("/", async (req, res) => {
-            if (req.body && req.body.action === "download" && req.body.presignedUrl) {
+            if (req.body && req.body.action === "download" && req.body.url) {
                 try {
                     await this.capability.downloadVoicePack({
-                        presignedUrl: req.body.presignedUrl,
+                        url: req.body.url,
                         language: req.body.language,
                         hash: req.body.hash
                     });

--- a/lib/webserver/capabilityRouters/VoicePackManagementCapabilityRouter.js
+++ b/lib/webserver/capabilityRouters/VoicePackManagementCapabilityRouter.js
@@ -6,7 +6,7 @@ class VoicePackManagementCapabilityRouter extends CapabilityRouter {
         this.router.get("/", async (req, res) => {
             res.json({
                 "currentLanguage": await this.capability.getCurrentVoiceLanguage(),
-                "operationProgress": await this.capability.getVoicePackOperationProgress()
+                "operationStatus": await this.capability.getVoicePackOperationStatus()
             });
         });
 

--- a/lib/webserver/capabilityRouters/index.js
+++ b/lib/webserver/capabilityRouters/index.js
@@ -17,5 +17,6 @@ module.exports = {
     MapSegmentationCapabilityRouter: require("./MapSegmentationCapabilityRouter"),
     DoNotDisturbCapabilityRouter: require("./DoNotDisturbCapabilityRouter"),
     CarpetModeControlCapabilityRouter: require("./CarpetModeControlCapabilityRouter"),
-    SpeakerTestCapabilityRouter: require("./SpeakerTestCapabilityRouter")
+    SpeakerTestCapabilityRouter: require("./SpeakerTestCapabilityRouter"),
+    VoicePackManagementCapabilityRouter: require("./VoicePackManagementCapabilityRouter"),
 };


### PR DESCRIPTION
## Type of change
  
Type B:
- [x] New capability


# Description (Type B)
Feature discussion thread: well...

As mentioned in Telegram, I don't think this way of implementing it makes it particularly complex (though slightly less user friendly).

I designed this as a single capability because, at least for the Viomi, separating the "apply local voice pack" and "download new voice pack" functionalities are very similar and creating two capabilities would increase duplication by a lot.

As far as I can tell all vacuums do not accept an upload, but they accept a URL from which they can download the pack. So I exposed it as such, uploading the pack to valetudo and having it serve it back to the vacuum software is quite messy and complex.

Functionality covers:

- Retrieving locally-available voice packs + voice packs that the vacuum or capability can retrieve autonomously
- Applying such voice packs
- Retrieving current voice pack language
- Optionally downloading a custom voice pack from URL
- Retrieving operation progress (which can be checked for both the download of a custom pack and for the application of an available voice pack)

The reason why I did not split this in two is that on Viomi the process of applying a local or remote voice pack is exactly the same.