### PR TITLE
fix(vendor.roborock): Fix S4 detection logic

### DIFF
--- a/lib/robots/roborock/RoborockS4ValetudoRobot.js
+++ b/lib/robots/roborock/RoborockS4ValetudoRobot.js
@@ -35,7 +35,7 @@ class RoborockS4ValetudoRobot extends RoborockValetudoRobot {
     static IMPLEMENTATION_AUTO_DETECTION_HANDLER() {
         const deviceConf = MiioValetudoRobot.READ_DEVICE_CONF(RoborockValetudoRobot.DEVICE_CONF_PATH);
 
-        return !!(deviceConf && deviceConf.model === (deviceConf.model === "roborock.vacuum.s4" || deviceConf.model === "roborock.vacuum.t4"));
+        return !!(deviceConf && (deviceConf.model === "roborock.vacuum.s4" || deviceConf.model === "roborock.vacuum.t4"));
     }
 }
 


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

Detection logic for the Roborock S4 / T4 was incorrect due to a typo. Fixing it :-) 
Didn't file an issue for this, though I can if you want to track. Noticed it as latest dustbuilder doesn't load Valetudo successfully with this error:
```
root@rockrobo:~# VALETUDO_CONFIG_PATH=/mnt/data/valetudo_config.json /usr/local/bin/valetudo
[2021-03-03T17:29:38.987Z] [INFO] Loading configuration file: /mnt/data/valetudo_config.json
[2021-03-03T17:29:39.013Z] [INFO] Set Logfile to /tmp/valetudo.log
[2021-03-03T17:29:39.029Z] [ERROR] Error while initializing robot implementation. Shutting down  Error: Couldn't find a suitable ValetudoRobot implementation.
    at Function.autodetectRobotImplementation (/snapshot/Valetudo/lib/core/ValetudoRobotFactory.js:52:19)
    at Function.getRobotImplementation (/snapshot/Valetudo/lib/core/ValetudoRobotFactory.js:16:45)
    at new Valetudo (/snapshot/Valetudo/lib/Valetudo.js:28:62)
    at Object.<anonymous> (/snapshot/Valetudo/index.js:5:16)
    at Module._compile (internal/modules/cjs/loader.js:1198:30)
    at Module._compile (pkg/prelude/bootstrap.js:1327:32)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1218:10)
    at Module.load (internal/modules/cjs/loader.js:1047:32)
    at Function.Module._load (internal/modules/cjs/loader.js:935:14)
    at Function.Module.runMain (pkg/prelude/bootstrap.js:1375:12)
```
