### PR TITLE
viomi: Ensure timezone is UTC

### DIFF
--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -85,6 +85,21 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
         this.tokenFilePath = ViomiValetudoRobot.TOKEN_FILE_PATH;
     }
 
+    onCloudConnected() {
+        super.onCloudConnected();
+
+        this.sendCommand("get_prop", ["timezone"]).then((res) => {
+            if (res.length > 0) {
+                const timezone = res[0];
+                if (timezone !== 0) {
+                    // Set timezone to UTC
+                    this.sendCommand("set_timezone", [0]).then(_ => {
+                    });
+                }
+            }
+        });
+    }
+
     onMessage(msg) {
         switch (msg.method) {
             case "_sync.gen_tmp_presigned_url":


### PR DESCRIPTION
As discussed #728

Ensures Viomi is set to UTC after cloud is connected.

Question: should I also adjust DND and schedules to the new timezone? The vacuum doesn't do it on its own, and I can bet we'll see issues "valetudo messed up my schedules".

I decided to keep it simple for now.