### PR TITLE
viomi: Speaker control capabilities

### DIFF
--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -82,6 +82,14 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
         this.registerCapability(new capabilities.ViomiVoicePackManagementCapability({
             robot: this
         }));
+
+        this.registerCapability(new capabilities.ViomiSpeakerTestCapability({
+            robot: this
+        }));
+
+        this.registerCapability(new capabilities.ViomiSpeakerVolumeControlCapability({
+            robot: this
+        }));
     }
 
     setEmbeddedParameters() {

--- a/lib/robots/viomi/capabilities/ViomiSpeakerTestCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiSpeakerTestCapability.js
@@ -1,0 +1,13 @@
+const SpeakerTestCapability = require("../../../core/capabilities/SpeakerTestCapability");
+
+class ViomiSpeakerTestCapability extends SpeakerTestCapability {
+    /**
+     * @returns {Promise<void>}
+     */
+    async playTestSound() {
+        // Viomi doesn't have a specific "test sound" command, so we just make it play the "I'm here" sound
+        await this.robot.sendCommand("set_resetpos", [1]);
+    }
+}
+
+module.exports = ViomiSpeakerTestCapability;

--- a/lib/robots/viomi/capabilities/ViomiSpeakerVolumeControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiSpeakerVolumeControlCapability.js
@@ -1,0 +1,34 @@
+const SpeakerVolumeControlCapability = require("../../../core/capabilities/SpeakerVolumeControlCapability");
+
+class ViomiSpeakerVolumeControlCapability extends SpeakerVolumeControlCapability {
+    /**
+     * Returns the current voice volume as percentage
+     *
+     * @returns {Promise<number>}
+     */
+    async getVolume() {
+        // This could be added to the polled state attributes but there's no reason to waste bandwidth and retrieve it
+        // all the time
+        const result = await this.robot.sendCommand("get_prop", ["v_state"], {});
+        // noinspection JSUnresolvedVariable
+        if (result.length < 1) {
+            throw new Error("Invalid volume returned by vacuum");
+        }
+        return result[0] * 10;
+    }
+
+    /**
+     * Sets the speaker volume
+     *
+     * @param {number} value
+     * @returns {Promise<void>}
+     */
+    async setVolume(value) {
+        const viomifiedVolume = Math.round(value / 10);
+        const args = [viomifiedVolume === 0 ? 0 : 1, viomifiedVolume];
+
+        await this.robot.sendCommand("set_voice", args, {});
+    }
+}
+
+module.exports = ViomiSpeakerVolumeControlCapability;

--- a/lib/robots/viomi/capabilities/ViomiSpeakerVolumeControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiSpeakerVolumeControlCapability.js
@@ -30,7 +30,7 @@ class ViomiSpeakerVolumeControlCapability extends LinuxAlsaSpeakerVolumeControlC
      */
     async setVolume(value) {
         const viomifiedVolume = Math.round(value / 10);
-        const args = [viomifiedVolume === 0 ? 0 : 1, viomifiedVolume];
+        const args = [value === 0 ? 0 : 1, viomifiedVolume];
 
         // First set the volume using miIO, so the vacum stores the value
         await this.robot.sendCommand("set_voice", args, {});

--- a/lib/robots/viomi/capabilities/ViomiSpeakerVolumeControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiSpeakerVolumeControlCapability.js
@@ -1,12 +1,16 @@
-const SpeakerVolumeControlCapability = require("../../../core/capabilities/SpeakerVolumeControlCapability");
+const LinuxAlsaSpeakerVolumeControlCapability = require("../../common/linuxCapabilities/LinuxAlsaSpeakerVolumeControlCapability");
 
-class ViomiSpeakerVolumeControlCapability extends SpeakerVolumeControlCapability {
+class ViomiSpeakerVolumeControlCapability extends LinuxAlsaSpeakerVolumeControlCapability {
     /**
      * Returns the current voice volume as percentage
      *
      * @returns {Promise<number>}
      */
     async getVolume() {
+        if (this.robot.config.get("embedded") === true) {
+            return await super.getVolume();
+        }
+
         // This could be added to the polled state attributes but there's no reason to waste bandwidth and retrieve it
         // all the time
         const result = await this.robot.sendCommand("get_prop", ["v_state"], {});
@@ -14,6 +18,7 @@ class ViomiSpeakerVolumeControlCapability extends SpeakerVolumeControlCapability
         if (result.length < 1) {
             throw new Error("Invalid volume returned by vacuum");
         }
+
         return result[0] * 10;
     }
 
@@ -27,7 +32,17 @@ class ViomiSpeakerVolumeControlCapability extends SpeakerVolumeControlCapability
         const viomifiedVolume = Math.round(value / 10);
         const args = [viomifiedVolume === 0 ? 0 : 1, viomifiedVolume];
 
+        // First set the volume using miIO, so the vacum stores the value
         await this.robot.sendCommand("set_voice", args, {});
+
+        if (this.robot.config.get("embedded") === true && value % 10 !== 0) {
+            // Then also adjust it with ALSA to get finer control
+            await super.setVolume(value);
+        }
+    }
+
+    getAlsaControlName() {
+        return "Lineout volume control";
     }
 }
 

--- a/lib/robots/viomi/capabilities/index.js
+++ b/lib/robots/viomi/capabilities/index.js
@@ -9,5 +9,7 @@ module.exports = {
     ViomiZoneCleaningCapability: require("./ViomiZoneCleaningCapability"),
     ViomiPersistentMapControlCapability: require("./ViomiPersistentMapControlCapability"),
     ViomiVoicePackManagementCapability: require("./ViomiVoicePackManagementCapability"),
-    ViomiCombinedVirtualRestrictionsCapability: require("./ViomiCombinedVirtualRestrictionsCapability")
+    ViomiCombinedVirtualRestrictionsCapability: require("./ViomiCombinedVirtualRestrictionsCapability"),
+    ViomiSpeakerTestCapability: require("./ViomiSpeakerTestCapability"),
+    ViomiSpeakerVolumeControlCapability: require("./ViomiSpeakerVolumeControlCapability"),
 };


### PR DESCRIPTION
Split from #723.

Implements `ViomiSpeakerVolumeControlCapability` and `ViomiSpeakerTestCapability`.

The former uses both miIO and the LinuxAlsa capability since miIO allows only for volume adjustment in the range 0-10. The capability sets the volume using miio so it is remembered, then performs fine adjustment using ALSA.