### PR TITLE
viomi: Manual control capability

### DIFF
--- a/lib/core/capabilities/ManualControlCapability.js
+++ b/lib/core/capabilities/ManualControlCapability.js
@@ -26,10 +26,9 @@ class ManualControlCapability extends Capability {
     /**
      * @abstract
      * @param {string} action
-     * @param {number} [duration] - duration in milliseconds
      * @returns {Promise<void>}
      */
-    async manualControl(action, duration) {
+    async manualControl(action) {
         throw new NotImplementedError();
     }
 

--- a/lib/robots/viomi/ViomiCommonAttributes.js
+++ b/lib/robots/viomi/ViomiCommonAttributes.js
@@ -1,4 +1,6 @@
 const stateAttrs = require("../../entities/state/attributes");
+const ValetudoSensor = require("../../entities/core/ValetudoSensor");
+const ValetudoManualControlAction = require("../../entities/core/ValetudoManualControlAction");
 
 // Common Viomi enums
 
@@ -44,6 +46,22 @@ const ViomiZoneCleaningCommand = Object.freeze({
     CLEAN_ZONE: 3
 });
 
+const ViomiSensorTypes = Object.freeze([
+    new ValetudoSensor({
+        type: ValetudoSensor.TYPE.ACCELEROMETER,
+        value: null,
+    }),
+]);
+
+const ViomiManualControlDirection = Object.freeze({
+    [ValetudoManualControlAction.FORWARD]: 1,
+    [ValetudoManualControlAction.COUNTERCLOCKWISE]: 2,
+    [ValetudoManualControlAction.CLOCKWISE]: 3,
+    [ValetudoManualControlAction.BACKWARDS]: 4,
+    [ValetudoManualControlAction.STOP]: 5,
+    ENTER_EXIT: 10,
+});
+
 const FAN_SPEEDS = Object.freeze({
     [stateAttrs.IntensityStateAttribute.VALUE.LOW]: 0,
     [stateAttrs.IntensityStateAttribute.VALUE.MEDIUM]: 1,
@@ -62,8 +80,10 @@ module.exports = {
     ViomiArea: ViomiArea,
     ViomiOperationMode: ViomiOperationMode,
     ViomiOperation: ViomiOperation,
+    ViomiManualControlDirection: ViomiManualControlDirection,
     ViomiMovementMode: ViomiMovementMode,
     ViomiZoneCleaningCommand: ViomiZoneCleaningCommand,
+    ViomiSensorTypes: ViomiSensorTypes,
     FAN_SPEEDS: FAN_SPEEDS,
     WATER_GRADES: WATER_GRADES
 };

--- a/lib/robots/viomi/ViomiCommonAttributes.js
+++ b/lib/robots/viomi/ViomiCommonAttributes.js
@@ -1,6 +1,6 @@
 const stateAttrs = require("../../entities/state/attributes");
-const ValetudoSensor = require("../../entities/core/ValetudoSensor");
 const ValetudoManualControlAction = require("../../entities/core/ValetudoManualControlAction");
+const ValetudoSensor = require("../../entities/core/ValetudoSensor");
 
 // Common Viomi enums
 

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -220,14 +220,22 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
             let statusValue;
             let statusMetaData = {};
 
+            const previousState = this.state.getFirstMatchingAttributeByConstructor(stateAttrs.StatusStateAttribute);
+
             //TODO: does it make sense to always take the error state value if there is any?
             if (ERROR_MAP[data["err_state"]] && ERROR_MAP[data["err_state"]].value !== null) {
                 error = ERROR_MAP[data["err_state"]];
             }
-            if (STATUS_MAP[data["run_state"]]) {
-                status = STATUS_MAP[data["run_state"]];
-                statusValue = status.value;
+            if (data["mode"] === 5 || ( data["mode"] === undefined && previousState && previousState.value === stateAttrs.StatusStateAttribute.VALUE.MANUAL_CONTROL)) {
+                // Manual control enabled, run_state would set the status to "cleaning"
+                statusValue = stateAttrs.StatusStateAttribute.VALUE.MANUAL_CONTROL;
+            } else {
+                if (STATUS_MAP[data["run_state"]]) {
+                    status = STATUS_MAP[data["run_state"]];
+                    statusValue = status.value;
+                }
             }
+
 
             if (error !== undefined) {
                 if (error.value === stateAttrs.StatusStateAttribute.VALUE.ERROR) {

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -120,6 +120,10 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
             robot: this
         }));
 
+        this.registerCapability(new capabilities.ViomiManualControlCapability({
+            robot: this
+        }));
+
         this.state.upsertFirstMatchingAttribute(new stateAttrs.AttachmentStateAttribute({
             type: stateAttrs.AttachmentStateAttribute.TYPE.DUSTBIN,
             attached: false

--- a/lib/robots/viomi/capabilities/ViomiManualControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiManualControlCapability.js
@@ -1,0 +1,56 @@
+const stateAttrs = require("../../../entities/state/attributes");
+const ManualControlCapability = require("../../../core/capabilities/ManualControlCapability");
+const ViomiManualControlDirection = require("../ViomiCommonAttributes").ViomiManualControlDirection;
+
+
+class ViomiManualControlCapability extends ManualControlCapability {
+    /**
+     * @private
+     * @param {number} direction
+     * @returns {Promise<void>}
+     */
+    async viomiMove(direction) {
+        await this.robot.sendCommand("set_direction", [direction]);
+    }
+
+    /**
+     * @private
+     * @returns {boolean}
+     */
+    isInManualControlMode() {
+        const state = this.robot.state.getFirstMatchingAttributeByConstructor(stateAttrs.StatusStateAttribute);
+        return !!(state && state.value === stateAttrs.StatusStateAttribute.VALUE.MANUAL_CONTROL);
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async enterManualControl() {
+        if (!this.isInManualControlMode()) {
+            await this.viomiMove(ViomiManualControlDirection.ENTER_EXIT);
+        }
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async leaveManualControl() {
+        if (this.isInManualControlMode()) {
+            await this.viomiMove(ViomiManualControlDirection.ENTER_EXIT);
+        }
+    }
+
+    /**
+     * @param {string} action
+     * @returns {Promise<void>}
+     */
+    async manualControl(action) {
+        // eslint-disable-next-line eqeqeq
+        if (ViomiManualControlDirection[action] == null) {
+            throw new Error("Invalid action");
+        }
+        await this.viomiMove(ViomiManualControlDirection[action]);
+    }
+}
+
+module.exports = ViomiManualControlCapability;

--- a/lib/robots/viomi/capabilities/ViomiManualControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiManualControlCapability.js
@@ -1,5 +1,5 @@
-const stateAttrs = require("../../../entities/state/attributes");
 const ManualControlCapability = require("../../../core/capabilities/ManualControlCapability");
+const stateAttrs = require("../../../entities/state/attributes");
 const ViomiManualControlDirection = require("../ViomiCommonAttributes").ViomiManualControlDirection;
 
 

--- a/lib/robots/viomi/capabilities/index.js
+++ b/lib/robots/viomi/capabilities/index.js
@@ -5,6 +5,7 @@ module.exports = {
     ViomiConsumableMonitoringCapability: require("./ViomiConsumableMonitoringCapability"),
     ViomiFanSpeedControlCapability: require("./ViomiFanSpeedControlCapability"),
     ViomiLocateCapability: require("./ViomiLocateCapability"),
+    ViomiManualControlCapability: require("./ViomiManualControlCapability"),
     ViomiMapResetCapability: require("./ViomiMapResetCapability"),
     ViomiMapSegmentEditCapability: require("./ViomiMapSegmentEditCapability"),
     ViomiMapSegmentRenameCapability: require("./ViomiMapSegmentRenameCapability"),

--- a/lib/webserver/capabilityRouters/ManualControlCapabilityRouter.js
+++ b/lib/webserver/capabilityRouters/ManualControlCapabilityRouter.js
@@ -29,7 +29,7 @@ class ManualControlCapabilityRouter extends CapabilityRouter {
             if (req.body && req.body.action) {
                 try {
                     // Duration is optional, default is controlled by implementations
-                    await this.capability.manualControl(req.body.action, req.body.duration);
+                    await this.capability.manualControl(req.body.action);
                     res.sendStatus(200);
                 } catch (e) {
                     Logger.warn("Error while performing manual control action " + req.body.action, e);


### PR DESCRIPTION
Split from #723.

Removes `duration` parameter from manual control capability since its implementation would be quite nasty, discussed here: https://github.com/Hypfer/Valetudo/pull/723#discussion_r586777054

Manual control capability is then added to Viomi.