### PR TITLE
Bind dummycloud after setting event listeners

### DIFF
--- a/lib/miio/Dummycloud.js
+++ b/lib/miio/Dummycloud.js
@@ -17,11 +17,12 @@ class Dummycloud {
         this.bindIP = options.bindIP;
 
         this.socket = dgram.createSocket("udp4");
-        this.socket.bind(Dummycloud.PORT, this.bindIP);
 
         this.socket.on("listening", () => {
             Logger.info("Dummycloud is spoofing " + this.spoofedIP + ":8053 on " + this.bindIP + ":" + Dummycloud.PORT);
         });
+
+        this.socket.bind(Dummycloud.PORT, this.bindIP);
 
         this.miioSocket = new MiioSocket({
             socket: this.socket,


### PR DESCRIPTION
In some cases the "Dummycloud is spoofing " + this.spoofedIP + ":8053 on " + this.bindIP + ":" + Dummycloud.PORT message may not be printed due to a race condition. This change binds the dummy cloud socket after setting up the log hook so that it doesn't race any more