### PR TITLE
viomi: Use marketing model name for viomi.v8

### DIFF
--- a/lib/robots/viomi/ViomiV8ValetudoRobot.js
+++ b/lib/robots/viomi/ViomiV8ValetudoRobot.js
@@ -15,7 +15,7 @@ class ViomiV8ValetudoRobot extends ViomiValetudoRobot {
     }
 
     getModelName() {
-        return "Xiaomi Mijia STYTJ02YM";
+        return "Xiaomi Mi Robot Vacuum-Mop P (STYTJ02YM - viomi.vacuum.v8)";
     }
 
     static IMPLEMENTATION_AUTO_DETECTION_HANDLER() {


### PR DESCRIPTION
And finally the last set of changes split from #723.

Changes the vacuum name displayed in settings>info from "Xiaomi Mijia STYTJ02YM" to "Xiaomi Mi Robot Vacuum-Mop P (STYTJ02YM - viomi.vacuum.v8)", since that's what it looks like it's sold as.

Or at least listings in my country call it like this.