### PR TITLE
viomi: ViomiMapSegmentationCapability

### DIFF
--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -95,6 +95,10 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
             robot: this
         }));
 
+        this.registerCapability(new capabilities.ViomiMapSegmentationCapability({
+            robot: this
+        }));
+
 
         this.state.upsertFirstMatchingAttribute(new stateAttrs.AttachmentStateAttribute({
             type: stateAttrs.AttachmentStateAttribute.TYPE.DUSTBIN,

--- a/lib/robots/viomi/capabilities/ViomiMapSegmentationCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiMapSegmentationCapability.js
@@ -1,0 +1,17 @@
+const Logger = require("../../../Logger");
+const MapSegmentationCapability = require("../../../core/capabilities/MapSegmentationCapability");
+
+class ViomiMapSegmentationCapability extends MapSegmentationCapability {
+    /**
+     * @param {Array<import("../../../entities/core/ValetudoMapSegment")>} segments
+     * @returns {Promise<void>}
+     */
+    async executeSegmentAction(segments) {
+        const segmentIds = segments.map(segment => segment.id);
+        Logger.trace("segments to clean: ", segmentIds);
+
+        await this.robot.sendCommand("set_mode_withroom", [0, 1, segmentIds.length, ...segmentIds], {});
+    }
+}
+
+module.exports = ViomiMapSegmentationCapability;

--- a/lib/robots/viomi/capabilities/index.js
+++ b/lib/robots/viomi/capabilities/index.js
@@ -5,6 +5,7 @@ module.exports = {
     ViomiConsumableMonitoringCapability: require("./ViomiConsumableMonitoringCapability"),
     ViomiFanSpeedControlCapability: require("./ViomiFanSpeedControlCapability"),
     ViomiLocateCapability: require("./ViomiLocateCapability"),
+    ViomiMapSegmentationCapability: require("./ViomiMapSegmentationCapability"),
     ViomiPersistentMapControlCapability: require("./ViomiPersistentMapControlCapability"),
     ViomiRawCommandCapability: require("./ViomiRawCommandCapability"),
     ViomiSpeakerTestCapability: require("./ViomiSpeakerTestCapability"),


### PR DESCRIPTION
## Type of change

- [x] Capability implementation for existing core capability

# Description

I added the ViomiMapSegmentationCapability using `set_mode_withroom`.

The change was tested on my viomi.v7 and works fine, except for the room with the id 11.
For some reason, the robot starts a full cleanup and uses an empty map when this room is specified. Has anyone an idea why this happens?


 