### PR TITLE
feat: capitalize robot states in UI

### DIFF
--- a/client/home.html
+++ b/client/home.html
@@ -66,6 +66,7 @@
             text-align: center;
             font-size: 1.2em;
             font-weight: 500;
+            text-transform: capitalize;
         }
 
         .robot-error {
@@ -88,6 +89,10 @@
 
         #robot-state-details-time {
             text-align: right;
+        }
+
+        #fanspeed-button, #watergrade-button, .action-sheet-button {
+            text-transform: capitalize;
         }
     </style>
 


### PR DESCRIPTION
Description:
I couldn't find a proper PR type for this very small UI improvement. 

I'm adding a `text-transform: capitalize` on certain fields that are filled with states coming from the backend.

It just looks nicer, first screenshot is before my change, the second one is after my change (look at `docked` vs `Docked`, water grade and such:

<img width="350" alt="image" src="https://user-images.githubusercontent.com/1036887/112021682-d483d500-8b31-11eb-87ca-3de576641dfa.png"> 
<img width="350" alt="image" src="https://user-images.githubusercontent.com/1036887/112021760-e9606880-8b31-11eb-8402-a75524161c03.png">

