### PR TITLE
feat(ui): Toggle button states depending on Robot Capabilities

### DIFF
--- a/client/settings-wifi.html
+++ b/client/settings-wifi.html
@@ -84,5 +84,9 @@
         #settings-wifi-input-ssid > input {
             text-align: right;
         }
+
+        #settings-wifi-current-connection-status-connected {
+            text-transform: capitalize;
+        }
     </style>
 </ons-page>

--- a/client/settings-wifi.js
+++ b/client/settings-wifi.js
@@ -22,7 +22,7 @@ async function updateSettingsWifiPage() {
         wifiCurrentConnectionStatusConnected.innerHTML = res.details.state;
         if (res.details.state === "connected") {
             wifiCurrentConnectionStatusSSID.innerHTML = res.ssid;
-            wifiCurrentConnectionStatusSignal.innerHTML = res.details.signal;
+            wifiCurrentConnectionStatusSignal.innerHTML = `${res.details.signal} dBm`;
 
             wifiInputSSID.value = res.ssid;
         }

--- a/client/settings.html
+++ b/client/settings.html
@@ -1,59 +1,74 @@
 <ons-page id="settings-page">
-    <ons-card onclick="fn.pushPage({'id': 'settings-info.html', 'title': 'Info'})">
+    <ons-card id="settings-info" onclick="fn.pushPage({'id': 'settings-info.html', 'title': 'Info'})">
         <div class="title"><ons-icon icon="fa-info"></ons-icon> Info</div>
         <div class="content">View device information</div>
     </ons-card>
 
-    <ons-card onclick="fn.pushPage({'id': 'settings-timers.html', 'title': 'Timers'})">
+    <ons-card id="settings-timers" onclick="fn.pushPage({'id': 'settings-timers.html', 'title': 'Timers'})">
         <div class="title"><ons-icon icon="fa-clock-o"></ons-icon> Timers</div>
         <div class="content">Manage timers</div>
     </ons-card>
 
-    <ons-card onclick="fn.pushPage({'id': 'settings-carpet-mode.html', 'title': 'Carpet Mode'})">
+    <ons-card id="settings-carpet-mode" onclick="fn.pushPage({'id': 'settings-carpet-mode.html', 'title': 'Carpet Mode'})">
         <div class="title"><ons-icon icon="fa-cart-arrow-down"></ons-icon> Carpet Mode</div>
         <div class="content">Configure carpet mode</div>
     </ons-card>
 
-    <ons-card onclick="fn.pushPage({'id': 'settings-persistent-data.html', 'title': 'Persistent Maps'})">
+    <ons-card id="settings-persistent-data" onclick="fn.pushPage({'id': 'settings-persistent-data.html', 'title': 'Persistent Maps'})">
         <div class="title"><ons-icon icon="fa-map"></ons-icon> Persistent Data</div>
         <div class="content">Configure the lab mode for enabling virtual walls etc.</div>
     </ons-card>
 
-    <ons-card onclick="fn.pushPage({'id': 'settings-consumables.html', 'title': 'Consumables'})">
+    <ons-card id="settings-consumables" onclick="fn.pushPage({'id': 'settings-consumables.html', 'title': 'Consumables'})">
         <div class="title"><ons-icon icon="fa-wrench"></ons-icon> Consumables</div>
         <div class="content">View and/or reset consumable usage counters</div>
     </ons-card>
 
     <!--
-    <ons-card onclick="fn.pushPage({'id': 'settings-cleaning-history.html', 'title': 'Cleaning History'})">
+    <ons-card id="settings=cleaning-history" onclick="fn.pushPage({'id': 'settings-cleaning-history.html', 'title': 'Cleaning History'})">
         <div class="title"><ons-icon icon="fa-history"></ons-icon> Cleaning History</div>
         <div class="content">View the cleaning history</div>
     </ons-card>
     -->
-    <ons-card onclick="fn.pushPage({'id': 'settings-wifi.html', 'title': 'Wifi'})">
+    <ons-card id="settings-wifi" onclick="fn.pushPage({'id': 'settings-wifi.html', 'title': 'Wifi'})">
         <div class="title"><ons-icon icon="fa-wifi"></ons-icon> Wifi</div>
         <div class="content">View/change wifi details and settings</div>
     </ons-card>
-    <ons-card onclick="fn.pushPage({'id': 'settings-mqtt.html', 'title': 'MQTT'})">
+    <ons-card id="settings-mqtt" onclick="fn.pushPage({'id': 'settings-mqtt.html', 'title': 'MQTT'})">
         <div class="title"><ons-icon icon="fa-rss"></ons-icon> MQTT</div>
         <div class="content">View/change MQTT settings</div>
     </ons-card>
     <!--
-    <ons-card onclick="fn.pushPage({'id': 'settings-token.html', 'title': 'Wifi'})">
+    <ons-card id="settings-token" onclick="fn.pushPage({'id': 'settings-token.html', 'title': 'Wifi'})">
         <div class="title"><ons-icon icon="fa-key"></ons-icon> Token</div>
         <div class="content">View the current token</div>
     </ons-card>
     -->
 
-    <ons-card onclick="fn.pushPage({'id': 'settings-sound-voice.html', 'title': 'Sound'})">
+    <ons-card id="settings-sound" onclick="fn.pushPage({'id': 'settings-sound-voice.html', 'title': 'Sound'})">
         <div class="title"><ons-icon icon="fa-volume-up"></ons-icon> Sound</div>
         <div class="content">Change the sound volume of the robot</div>
     </ons-card>
 
-    <ons-card onclick="fn.pushPage({'id': 'settings-access-control.html', 'title': 'Access Control'})">
+    <ons-card id="settings-access-control" onclick="fn.pushPage({'id': 'settings-access-control.html', 'title': 'Access Control'})">
         <div class="title"><ons-icon icon="fa-lock"></ons-icon> Access Control</div>
         <div class="content">Configure SSH keys and HTTP authentication</div>
     </ons-card>
+
+    <script>
+        {
+          let s = document.createElement('script');
+          s.src = "settings.js";
+          s.type = "module";
+          s.crossOrigin = "use-credentials";
+          ons.getScriptPage().appendChild(s);
+
+          ons.getScriptPage().onShow = function() {
+              updateSettingsPage();
+          };
+        }
+    </script>
+
     <style>
         .intro {
             text-align: center;

--- a/client/settings.js
+++ b/client/settings.js
@@ -46,8 +46,6 @@ async function updateSettingsPage() {
 
         Object.keys(buttonStateMap).forEach((key) => {
             const state = buttonStateMap[key];
-            console.log('element ', key)
-            console.log('show', state);
             const element = document.getElementById(`settings-${key}`);
 
             if (element && !state) {

--- a/client/settings.js
+++ b/client/settings.js
@@ -1,31 +1,5 @@
 /*global ons */
 import {ApiService} from "./services/api.service.js";
-/*
-    BasicControlCapability: require("./BasicControlCapability"),
-    CarpetModeControlCapability: require("./CarpetModeControlCapability"),
-    CombinedVirtualRestrictionsCapability: require("./CombinedVirtualRestrictionsCapability"),
-    ConsumableMonitoringCapability: require("./ConsumableMonitoringCapability"),
-    DoNotDisturbCapability: require("./DoNotDisturbCapability"),
-    FanSpeedControlCapability: require("./FanSpeedControlCapability"),
-    GoToLocationCapability: require("./GoToLocationCapability"),
-    IntensityPresetCapability: require("./IntensityPresetCapability"),
-    LEDControlCapability: require("./LEDControlCapability"),
-    LocateCapability: require("./LocateCapability"),
-    ManualControlCapability: require("./ManualControlCapability"),
-    MapResetCapability: require("./MapResetCapability"),
-    MapSegmentEditCapability: require("./MapSegmentEditCapability"),
-    MapSegmentationCapability: require("./MapSegmentationCapability"),
-    MapSnapshotCapability: require("./MapSnapshotCapability"),
-    PersistentMapControlCapability: require("./PersistentMapControlCapability"),
-    RawCommandCapability: require("./RawCommandCapability"),
-    SensorCalibrationCapability: require("./SensorCalibrationCapability"),
-    SpeakerTestCapability: require("./SpeakerTestCapability"),
-    SpeakerVolumeControlCapability: require("./SpeakerVolumeControlCapability"),
-    VoicePackManagementCapability: require("./VoicePackManagementCapability"),
-    WaterUsageControlCapability: require("./WaterUsageControlCapability"),
-    WifiConfigurationCapability: require("./WifiConfigurationCapability"),
-    ZoneCleaningCapability: require("./ZoneCleaningCapability")
-*/
 
 async function updateSettingsPage() {
     try {

--- a/client/settings.js
+++ b/client/settings.js
@@ -12,10 +12,10 @@ async function updateSettingsPage() {
             "persistent-data": robotCapabilities.includes("PersistentMapControlCapability"),
             consumables: robotCapabilities.includes("ConsumableMonitoringCapability"),
             wifi: robotCapabilities.includes("WifiConfigurationCapability"),
-            mqtt: robotCapabilities.includes("WifiConfigurationCapability"),
+            mqtt: true,
             token: false, // commented out in settings.html?
             sound: robotCapabilities.includes("SpeakerVolumeControlCapability"),
-            "access-control": robotCapabilities.includes("WifiConfigurationCapability")
+            "access-control": true
         };
 
         Object.keys(buttonStateMap).forEach((key) => {

--- a/client/settings.js
+++ b/client/settings.js
@@ -1,0 +1,65 @@
+/*global ons */
+import {ApiService} from "./services/api.service.js";
+/*
+    BasicControlCapability: require("./BasicControlCapability"),
+    CarpetModeControlCapability: require("./CarpetModeControlCapability"),
+    CombinedVirtualRestrictionsCapability: require("./CombinedVirtualRestrictionsCapability"),
+    ConsumableMonitoringCapability: require("./ConsumableMonitoringCapability"),
+    DoNotDisturbCapability: require("./DoNotDisturbCapability"),
+    FanSpeedControlCapability: require("./FanSpeedControlCapability"),
+    GoToLocationCapability: require("./GoToLocationCapability"),
+    IntensityPresetCapability: require("./IntensityPresetCapability"),
+    LEDControlCapability: require("./LEDControlCapability"),
+    LocateCapability: require("./LocateCapability"),
+    ManualControlCapability: require("./ManualControlCapability"),
+    MapResetCapability: require("./MapResetCapability"),
+    MapSegmentEditCapability: require("./MapSegmentEditCapability"),
+    MapSegmentationCapability: require("./MapSegmentationCapability"),
+    MapSnapshotCapability: require("./MapSnapshotCapability"),
+    PersistentMapControlCapability: require("./PersistentMapControlCapability"),
+    RawCommandCapability: require("./RawCommandCapability"),
+    SensorCalibrationCapability: require("./SensorCalibrationCapability"),
+    SpeakerTestCapability: require("./SpeakerTestCapability"),
+    SpeakerVolumeControlCapability: require("./SpeakerVolumeControlCapability"),
+    VoicePackManagementCapability: require("./VoicePackManagementCapability"),
+    WaterUsageControlCapability: require("./WaterUsageControlCapability"),
+    WifiConfigurationCapability: require("./WifiConfigurationCapability"),
+    ZoneCleaningCapability: require("./ZoneCleaningCapability")
+*/
+
+async function updateSettingsPage() {
+    try {
+        const robotCapabilities = await ApiService.getCapabilities() || [];
+        const buttonStateMap = {
+            info: true,
+            timers: robotCapabilities.includes("DoNotDisturbCapability"),
+            "carpet-mode": robotCapabilities.includes("CarpetModeControlCapability"),
+            "cleaning-history": false, // commented out in settings.html?
+            "persistent-data": robotCapabilities.includes("PersistentMapControlCapability"),
+            consumables: robotCapabilities.includes("ConsumableMonitoringCapability"),
+            wifi: robotCapabilities.includes("WifiConfigurationCapability"),
+            mqtt: robotCapabilities.includes("WifiConfigurationCapability"),
+            token: false, // commented out in settings.html?
+            sound: robotCapabilities.includes("SpeakerVolumeControlCapability"),
+            "access-control": robotCapabilities.includes("WifiConfigurationCapability")
+        };
+
+        Object.keys(buttonStateMap).forEach((key) => {
+            const state = buttonStateMap[key];
+            console.log('element ', key)
+            console.log('show', state);
+            const element = document.getElementById(`settings-${key}`);
+
+            if (element && !state) {
+                element.style = "display: none;";
+            }
+
+        });
+    } catch (err) {
+        ons.notification.toast(`Error: ${err.message}`,
+            { buttonLabel: "Dismiss", timeout: window.fn.toastErrorTimeout });
+    }
+}
+
+
+window.updateSettingsPage = updateSettingsPage;


### PR DESCRIPTION
Description: 
This PR entails toggling the button states based on the capabilities reported by the Valetudo backend in:
- Home page
- Settings page

I also encountered some minor cosmetic things that I included in this PR such as:
- Add `dBm` unit to the WiFi signal settings field
- Capitalize `WiFi Status`