### PR TITLE
fix(ui): instead of hiding settings based on capabilities at page load, unhide at page load

### DIFF
--- a/client/home.html
+++ b/client/home.html
@@ -6,28 +6,28 @@
         </p>
         <div style="width:100%; text-align:center;">
             <p id="robot-state-details">
-                <span id="robot-state-details-m2">Area: ???.?? m²</span>
-                <span id="robot-state-details-time">Time: ??:??:??</span>
+                <span id="robot-state-details-m2" hidden="true">Area: ???.?? m²</span>
+                <span id="robot-state-details-time" hidden="true">Time: ??:??:??</span>
             </p>
         </div>
     </section>
     <hr style="width:98%; opacity: 0.3">
 
     <section id="robot-control-buttons">
-        <ons-button id="start-button" class="button-margin" onclick="handleControlButton('start')" style="width:40%"><ons-icon icon="fa-play"></ons-icon> Start</ons-button>
-        <ons-button id="pause-button" class="button-margin" onclick="handleControlButton('pause')" style="width:40%"><ons-icon icon="fa-pause"></ons-icon> Pause</ons-button>
+        <ons-button id="start-button" disabled="disabled" class="button-margin" onclick="handleControlButton('start')" style="width:40%"><ons-icon icon="fa-play"></ons-icon> Start</ons-button>
+        <ons-button id="pause-button" disabled="disabled" class="button-margin" onclick="handleControlButton('pause')" style="width:40%"><ons-icon icon="fa-pause"></ons-icon> Pause</ons-button>
         <br>
-        <ons-button id="stop-button" class="button-margin" onclick="handleControlButton('stop')" style="width:40%"><ons-icon icon="fa-stop"></ons-icon> Stop</ons-button>
-        <ons-button id="home-button" class="button-margin" onclick="handleControlButton('home')" style="width:40%"><ons-icon icon="fa-home"></ons-icon> Home</ons-button>
+        <ons-button id="stop-button" disabled="disabled" class="button-margin" onclick="handleControlButton('stop')" style="width:40%"><ons-icon icon="fa-stop"></ons-icon> Stop</ons-button>
+        <ons-button id="home-button" disabled="disabled" class="button-margin" onclick="handleControlButton('home')" style="width:40%"><ons-icon icon="fa-home"></ons-icon> Home</ons-button>
         <br>
-        <ons-button id="spot-button" class="button-margin" onclick="handleControlButton('spot')" style="width:40%"><ons-icon icon="fa-caret-down"></ons-icon> Spot</ons-button>
-        <ons-button id="find-robot-button" class="button-margin" onclick="handleControlButton('find')" style="width:40%"><ons-icon icon="fa-map-marker"></ons-icon> Find</ons-button>
+        <ons-button id="spot-button" disabled="disabled" class="button-margin" onclick="handleControlButton('spot')" style="width:40%"><ons-icon icon="fa-caret-down"></ons-icon> Spot</ons-button>
+        <ons-button id="find-robot-button" disabled="disabled" class="button-margin" onclick="handleControlButton('find')" style="width:40%"><ons-icon icon="fa-map-marker"></ons-icon> Find</ons-button>
         <br>
-        <ons-button id="go-to-button" class="button-margin" onclick="handleGoToButton()" disabled style="width:40%"><ons-icon icon="fa-map-signs"></ons-icon> Go to </ons-button>
-        <ons-button id="area-button" class="button-margin" onclick="handleZonesButton()" disabled style="width:40%"><ons-icon icon="fa-map"></ons-icon> Zones </ons-button>
+        <ons-button id="go-to-button" disabled="disabled" class="button-margin" onclick="handleGoToButton()" disabled style="width:40%"><ons-icon icon="fa-map-signs"></ons-icon> Go to </ons-button>
+        <ons-button id="area-button" disabled="disabled" class="button-margin" onclick="handleZonesButton()" disabled style="width:40%"><ons-icon icon="fa-map"></ons-icon> Zones </ons-button>
         <br>
-        <ons-button id="fanspeed-button" class="button-margin" onclick="handleFanspeedButton()" disabled style="width:40%"><ons-icon icon="fa-superpowers"></ons-icon> Unknown power</ons-button>
-        <ons-button id="watergrade-button" class="button-margin" onclick="handleWaterGradeButton()" disabled style="width:40%; display:none;"><ons-icon icon="fa-tint"></ons-icon> Unknown Water Grade</ons-button>
+        <ons-button id="fanspeed-button" disabled="disabled" class="button-margin" onclick="handleFanspeedButton()" disabled style="width:40%"><ons-icon icon="fa-superpowers"></ons-icon> Unknown power</ons-button>
+        <ons-button id="watergrade-button" disabled="disabled" class="button-margin" onclick="handleWaterGradeButton()" disabled style="width:40%; display:none;"><ons-icon icon="fa-tint"></ons-icon> Unknown Water Grade</ons-button>
     </section>
     <hr style="width:98%; opacity: 0.3">
 

--- a/client/home.js
+++ b/client/home.js
@@ -260,8 +260,6 @@ async function updateHomePage() {
         loadingBarHome.removeAttribute("indeterminate");
         fanspeedButton.removeAttribute("disabled");
         watergradeButton.removeAttribute("disabled");
-        findRobotButton.removeAttribute("disabled");
-        spotButton.removeAttribute("disabled");
 
         const buttonMap = {
             start: startButton,
@@ -343,6 +341,7 @@ async function updateHomePage() {
         }
 
         if (AreaCleanupStatsAttribute) {
+            robotStateDetailsM2.hidden = false;
             robotStateDetailsM2.innerHTML = "Area: " +
                 ("00" + (AreaCleanupStatsAttribute.value / 10000).toFixed(2)).slice(-6) + " m²";
         } else {
@@ -350,6 +349,7 @@ async function updateHomePage() {
         }
 
         if (DurationCleanupStatsAttribute) {
+            robotStateDetailsTime.hidden = false;
             robotStateDetailsTime.innerHTML = "Time: " + secondsToHms(DurationCleanupStatsAttribute.value);
         } else {
             robotStateDetailsTime.hidden = true;

--- a/client/settings.html
+++ b/client/settings.html
@@ -1,56 +1,56 @@
 <ons-page id="settings-page">
-    <ons-card id="settings-info" onclick="fn.pushPage({'id': 'settings-info.html', 'title': 'Info'})">
+    <ons-card id="settings-info" class="hidden" onclick="fn.pushPage({'id': 'settings-info.html', 'title': 'Info'})">
         <div class="title"><ons-icon icon="fa-info"></ons-icon> Info</div>
         <div class="content">View device information</div>
     </ons-card>
 
-    <ons-card id="settings-timers" onclick="fn.pushPage({'id': 'settings-timers.html', 'title': 'Timers'})">
+    <ons-card id="settings-timers" class="hidden" onclick="fn.pushPage({'id': 'settings-timers.html', 'title': 'Timers'})">
         <div class="title"><ons-icon icon="fa-clock-o"></ons-icon> Timers</div>
         <div class="content">Manage timers</div>
     </ons-card>
 
-    <ons-card id="settings-carpet-mode" onclick="fn.pushPage({'id': 'settings-carpet-mode.html', 'title': 'Carpet Mode'})">
+    <ons-card id="settings-carpet-mode" class="hidden" onclick="fn.pushPage({'id': 'settings-carpet-mode.html', 'title': 'Carpet Mode'})">
         <div class="title"><ons-icon icon="fa-cart-arrow-down"></ons-icon> Carpet Mode</div>
         <div class="content">Configure carpet mode</div>
     </ons-card>
 
-    <ons-card id="settings-persistent-data" onclick="fn.pushPage({'id': 'settings-persistent-data.html', 'title': 'Persistent Maps'})">
+    <ons-card id="settings-persistent-data" class="hidden" onclick="fn.pushPage({'id': 'settings-persistent-data.html', 'title': 'Persistent Maps'})">
         <div class="title"><ons-icon icon="fa-map"></ons-icon> Persistent Data</div>
         <div class="content">Configure the lab mode for enabling virtual walls etc.</div>
     </ons-card>
 
-    <ons-card id="settings-consumables" onclick="fn.pushPage({'id': 'settings-consumables.html', 'title': 'Consumables'})">
+    <ons-card id="settings-consumables" class="hidden" onclick="fn.pushPage({'id': 'settings-consumables.html', 'title': 'Consumables'})">
         <div class="title"><ons-icon icon="fa-wrench"></ons-icon> Consumables</div>
         <div class="content">View and/or reset consumable usage counters</div>
     </ons-card>
 
     <!--
-    <ons-card id="settings=cleaning-history" onclick="fn.pushPage({'id': 'settings-cleaning-history.html', 'title': 'Cleaning History'})">
+    <ons-card id="settings=cleaning-history" class="hidden" onclick="fn.pushPage({'id': 'settings-cleaning-history.html', 'title': 'Cleaning History'})">
         <div class="title"><ons-icon icon="fa-history"></ons-icon> Cleaning History</div>
         <div class="content">View the cleaning history</div>
     </ons-card>
     -->
-    <ons-card id="settings-wifi" onclick="fn.pushPage({'id': 'settings-wifi.html', 'title': 'Wifi'})">
+    <ons-card id="settings-wifi" class="hidden" onclick="fn.pushPage({'id': 'settings-wifi.html', 'title': 'Wifi'})">
         <div class="title"><ons-icon icon="fa-wifi"></ons-icon> Wifi</div>
         <div class="content">View/change wifi details and settings</div>
     </ons-card>
-    <ons-card id="settings-mqtt" onclick="fn.pushPage({'id': 'settings-mqtt.html', 'title': 'MQTT'})">
+    <ons-card id="settings-mqtt" class="hidden" onclick="fn.pushPage({'id': 'settings-mqtt.html', 'title': 'MQTT'})">
         <div class="title"><ons-icon icon="fa-rss"></ons-icon> MQTT</div>
         <div class="content">View/change MQTT settings</div>
     </ons-card>
     <!--
-    <ons-card id="settings-token" onclick="fn.pushPage({'id': 'settings-token.html', 'title': 'Wifi'})">
+    <ons-card id="settings-token" class="hidden" onclick="fn.pushPage({'id': 'settings-token.html', 'title': 'Wifi'})">
         <div class="title"><ons-icon icon="fa-key"></ons-icon> Token</div>
         <div class="content">View the current token</div>
     </ons-card>
     -->
 
-    <ons-card id="settings-sound" onclick="fn.pushPage({'id': 'settings-sound-voice.html', 'title': 'Sound'})">
+    <ons-card id="settings-sound" class="hidden" onclick="fn.pushPage({'id': 'settings-sound-voice.html', 'title': 'Sound'})">
         <div class="title"><ons-icon icon="fa-volume-up"></ons-icon> Sound</div>
         <div class="content">Change the sound volume of the robot</div>
     </ons-card>
 
-    <ons-card id="settings-access-control" onclick="fn.pushPage({'id': 'settings-access-control.html', 'title': 'Access Control'})">
+    <ons-card id="settings-access-control" class="hidden" onclick="fn.pushPage({'id': 'settings-access-control.html', 'title': 'Access Control'})">
         <div class="title"><ons-icon icon="fa-lock"></ons-icon> Access Control</div>
         <div class="content">Configure SSH keys and HTTP authentication</div>
     </ons-card>
@@ -79,6 +79,10 @@
         ons-card {
             cursor: pointer;
             color: #333;
+        }
+
+        ons-card.hidden {
+            display: none;
         }
 
         .card__title,

--- a/client/settings.js
+++ b/client/settings.js
@@ -17,13 +17,20 @@ async function updateSettingsPage() {
             sound: robotCapabilities.includes("SpeakerVolumeControlCapability"),
             "access-control": true
         };
+        console.dir(buttonStateMap)
 
         Object.keys(buttonStateMap).forEach((key) => {
             const state = buttonStateMap[key];
             const element = document.getElementById(`settings-${key}`);
-
-            if (element && !state) {
-                element.style = "display: none;";
+            if (element) {
+                console.log('found', key, state)
+                if (state === true) {
+                    element.classList.remove("hidden");
+                } else {
+                    element.classList.add("hidden");
+                }
+            } else {
+                console.log('couldnt find', key)
             }
 
         });

--- a/client/settings.js
+++ b/client/settings.js
@@ -17,20 +17,16 @@ async function updateSettingsPage() {
             sound: robotCapabilities.includes("SpeakerVolumeControlCapability"),
             "access-control": true
         };
-        console.dir(buttonStateMap)
 
         Object.keys(buttonStateMap).forEach((key) => {
             const state = buttonStateMap[key];
             const element = document.getElementById(`settings-${key}`);
             if (element) {
-                console.log('found', key, state)
                 if (state === true) {
                     element.classList.remove("hidden");
                 } else {
                     element.classList.add("hidden");
                 }
-            } else {
-                console.log('couldnt find', key)
             }
 
         });


### PR DESCRIPTION
Description:

This PR is a follow-up on #769 
It addresses @Hypfer 's [comment](https://github.com/Hypfer/Valetudo/pull/769#issuecomment-804421303) on that PR to toggle button states / settings view items based on Robot Capabilities.

```
Hiding elements by default and only unhiding them if they're actually available would be even better.

Now, I see stuff disappearing when I open the settings page
```