### PR TITLE
viomi: Fix basic control functionality

### DIFF
--- a/lib/robots/viomi/ViomiCommonAttributes.js
+++ b/lib/robots/viomi/ViomiCommonAttributes.js
@@ -21,7 +21,8 @@ const ViomiBoxType = Object.freeze({
 const ViomiOperation = Object.freeze({
     STOP: 0,
     START: 1,
-    PAUSE: 2
+    PAUSE: 2,
+    PAUSE_RECTANGULAR_ZONE: 3
 });
 
 /** @enum {number} */
@@ -32,10 +33,15 @@ const ViomiArea = Object.freeze({
 
 /** @enum {number} */
 const ViomiMovementMode = Object.freeze({
-    NORMAL_CLEANING: 0,
-    MOP_MOVES: 1,  // back and forth mopping movement (unsure if this has an effect without mop-mode)
-    OUTLINE: 2,  // Only clean the rooms outline.
-    ZONED_CLEAN_OR_MOPPING: 3,
+    NORMAL_CLEANING: 0, // goes in straight lines with vacuum motor on
+    VACUUM_AND_MOP: 1,  // back and forth mopping movement with vacuum motor on
+    OUTLINE: 2,         // only clean the rooms outline
+    MOP_NO_VACUUM: 3,   // same as VACUUM_AND_MOP, but the vacuum motor is turned off
+});
+
+const ViomiZoneCleaningCommand = Object.freeze({
+    STOP: 0,
+    CLEAN_ZONE: 3
 });
 
 const FAN_SPEEDS = Object.freeze({
@@ -57,6 +63,7 @@ module.exports = {
     ViomiOperationMode: ViomiOperationMode,
     ViomiOperation: ViomiOperation,
     ViomiMovementMode: ViomiMovementMode,
+    ViomiZoneCleaningCommand: ViomiZoneCleaningCommand,
     FAN_SPEEDS: FAN_SPEEDS,
     WATER_GRADES: WATER_GRADES
 };

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -38,7 +38,7 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
         }
 
         this.ephemeralState = {
-            carpetModeEnabled: false,
+            carpetModeEnabled: undefined,
             lastOperationType: null,
             lastOperationAdditionalParams: []
         };

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -199,7 +199,7 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
     }
 
     async pollState() {
-        const response = await this.sendCommand("get_prop", STATE_PROPERTIES);
+        const response = await this.sendCommand("get_prop", STATE_PROPERTIES, {timeout: 3000});
 
         if (response) {
             let statusDict = {};

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -251,6 +251,12 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
             if (this.ephemeralState.lastOperationType !== null &&
                 (statusValue === stateAttrs.StatusStateAttribute.VALUE.CLEANING || statusValue === stateAttrs.StatusStateAttribute.VALUE.PAUSED)) {
                 statusFlag = this.ephemeralState.lastOperationType;
+            } else if (this.ephemeralState.lastOperationType !== null && statusValue === stateAttrs.StatusStateAttribute.VALUE.RETURNING) {
+                // Operation completed without pausing, cleanup last operation so we don't try to resume next time
+                // We only cleanup on "RETURNING" to avoid race conditions in case we set lastOperation and the vacuum
+                // takes some time to update the status.
+                this.ephemeralState.lastOperationType = null;
+                this.ephemeralState.lastOperationAdditionalParams = [];
             }
 
             //TODO: trigger re-poll of map if new status is fast polling state

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -39,6 +39,8 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
 
         this.ephemeralState = {
             carpetModeEnabled: false,
+            lastOperationType: null,
+            lastOperationAdditionalParams: []
         };
 
         this.registerCapability(new capabilities.ViomiBasicControlCapability({
@@ -527,7 +529,7 @@ const STATUS_MAP = Object.freeze({
         value: stateAttrs.StatusStateAttribute.VALUE.PAUSED
     },
     3: {
-        value: stateAttrs.StatusStateAttribute.VALUE.CLEANING
+        value: stateAttrs.StatusStateAttribute.VALUE.CLEANING  // Vacuuming
     },
     4: {
         value: stateAttrs.StatusStateAttribute.VALUE.RETURNING
@@ -539,7 +541,7 @@ const STATUS_MAP = Object.freeze({
         value: stateAttrs.StatusStateAttribute.VALUE.CLEANING  // Vacuuming and mopping
     },
     7: {
-        value: stateAttrs.StatusStateAttribute.VALUE.CLEANING  // Mopping (?)
+        value: stateAttrs.StatusStateAttribute.VALUE.CLEANING  // Mopping
     }
 });
 

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -517,10 +517,10 @@ const STATUS_MAP = Object.freeze({
         value: stateAttrs.StatusStateAttribute.VALUE.IDLE
     },
     1: {
-        value: stateAttrs.StatusStateAttribute.VALUE.PAUSED
+        value: stateAttrs.StatusStateAttribute.VALUE.IDLE
     },
     2: {
-        value: stateAttrs.StatusStateAttribute.VALUE.IDLE
+        value: stateAttrs.StatusStateAttribute.VALUE.PAUSED
     },
     3: {
         value: stateAttrs.StatusStateAttribute.VALUE.CLEANING
@@ -533,6 +533,9 @@ const STATUS_MAP = Object.freeze({
     },
     6: {
         value: stateAttrs.StatusStateAttribute.VALUE.CLEANING  // Vacuuming and mopping
+    },
+    7: {
+        value: stateAttrs.StatusStateAttribute.VALUE.CLEANING  // Mopping (?)
     }
 });
 

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -37,6 +37,10 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
             this.waterGrades = attributes.WATER_GRADES;
         }
 
+        this.ephemeralState = {
+            carpetModeEnabled: false,
+        };
+
         this.registerCapability(new capabilities.ViomiBasicControlCapability({
             robot: this
         }));

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -247,8 +247,11 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
                 }
             }
 
-            // TODO: stub - set meaningful value
-            const statusFlag = stateAttrs.StatusStateAttribute.FLAG.NONE;
+            let statusFlag = stateAttrs.StatusStateAttribute.FLAG.NONE;
+            if (this.ephemeralState.lastOperationType !== null &&
+                (statusValue === stateAttrs.StatusStateAttribute.VALUE.CLEANING || statusValue === stateAttrs.StatusStateAttribute.VALUE.PAUSED)) {
+                statusFlag = this.ephemeralState.lastOperationType;
+            }
 
             //TODO: trigger re-poll of map if new status is fast polling state
             newStateAttr = new stateAttrs.StatusStateAttribute({

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -543,12 +543,12 @@ const STATUS_MAP = Object.freeze({
 const ERROR_MAP = Object.freeze({
     500: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Lidar sensor timeout"
+        desc: "Lidar sensor timeout - ensure laser is not blocked"
     },
 
     501: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Wheels stuck"
+        desc: "Wheels suspended - place the vacuum on a flat surface"
     },
 
     502: {
@@ -558,7 +558,7 @@ const ERROR_MAP = Object.freeze({
 
     503: { // invalid mop mode (e.g. mop without mop installed)
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Dust bin is not installed"
+        desc: "Dust bin or 2-in-1 dust bin is not installed"
     },
 
     // robot cannot find its location, but its required for the specified mode (e.g. spot clean)
@@ -569,47 +569,47 @@ const ERROR_MAP = Object.freeze({
 
     508: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Uneven ground"
+        desc: "Uneven ground - place the vacuum on a flat surface or perform sensor calibration"
     },
 
     509: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Cliff sensor error"
+        desc: "Cliff sensor error - wipe sensors clean with a cloth"
     },
 
     510: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Collision sensor error" //RETURN_HOME
+        desc: "Collision sensor error - remove foreign objects from sensors" //RETURN_HOME
     },
 
     511: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Could not return to dock" // TODO: see why error is duplicated
+        desc: "Could not return to dock"
     },
 
     512: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Could not return to dock" // TODO: see why error is duplicated
+        desc: "Could not return to dock"
     },
 
     513: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Could not navigate to location"
+        desc: "Could not navigate to location - remove any obstacles"
     },
 
     514: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Vacuum is stuck"
+        desc: "Vacuum is stuck - remove any obstacles"
     },
 
     515: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Charging error"
+        desc: "Charging error - clean the charging contacts on the back"
     },
 
     516: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Mop temperature error"
+        desc: "Vacuum temperature error - wait for the vacuum to cool down"
     },
 
     521: {
@@ -634,7 +634,7 @@ const ERROR_MAP = Object.freeze({
 
     528: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Dust bin is not installed"
+        desc: "Dust bin or 2-in-1 dust bin is not installed"
     },
 
     529: {
@@ -644,12 +644,17 @@ const ERROR_MAP = Object.freeze({
 
     530: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Mop and water tank are not installed"
+        desc: "Mop and 2-in-1 dust-bin + water tank are not installed"
     },
 
     531: {
         value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
-        desc: "Water tank not installed"
+        desc: "2-in-1 dust bin + water tank not installed"
+    },
+
+    537: {
+        value: stateAttrs.StatusStateAttribute.VALUE.ERROR,
+        desc: "Not cleaning because of do-not-disturb settings"
     },
 
     2101: {

--- a/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
@@ -78,7 +78,17 @@ class ViomiBasicControlCapability extends BasicControlCapability {
     }
 
     async stop() {
-        await this.robot.sendCommand("set_mode", [attributes.ViomiOperation.STOP]);
+        const statusAttribute = this.robot.state.getFirstMatchingAttributeByConstructor(
+            stateAttrs.StatusStateAttribute
+        );
+        if (statusAttribute && statusAttribute.VALUE === stateAttrs.StatusStateAttribute.VALUE.RETURNING) {
+            // With the "stop returning" command as opposed to the common "stop" the voice provides the correct feedback
+            await this.robot.sendCommand("set_charge", [0]);
+        } else if (statusAttribute && statusAttribute.VALUE === stateAttrs.StatusStateAttribute.VALUE.CLEANING) {
+            await this.robot.sendCommand("set_mode", [3, 0]);
+        } else {
+            await this.robot.sendCommand("set_mode", [attributes.ViomiOperation.STOP]);
+        }
     }
 
     // TODO: test

--- a/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
@@ -1,9 +1,23 @@
 const BasicControlCapability = require("../../../core/capabilities/BasicControlCapability");
+const Logger = require("../../../Logger");
+
 
 const attributes = require("../ViomiCommonAttributes");
 const stateAttrs = require("../../../entities/state/attributes");
 
 /**
+ * This capability provides methods to start, stop, pause and resume the current cleaning operation.
+ * The vacuum expects the control software to remember the parameters of the last cleaning command, and re-submit them
+ * when pausing or resuming.
+ *
+ * For this reasons, no other capability should run the following commands on their own:
+ * - set_mode - use setRectangularZoneMode() or stop() instead
+ * - set_mode_withroom - use setModeWithSegments() instead
+ * - set_pointclean - use setModeCleanSpot() instead
+ *
+ * They should instead prepare their data, retrieve this capability and use it to perform the operation.
+ * This capability will take care of remembering the parameters for subsequent pause/resume commands.
+ *
  * @extends BasicControlCapability<import("../ViomiValetudoRobot")>
  */
 class ViomiBasicControlCapability extends BasicControlCapability {
@@ -11,9 +25,10 @@ class ViomiBasicControlCapability extends BasicControlCapability {
     /**
      * Automatically sets mop mode depending on what tools are currently installed
      *
+     * @private
      * @returns {attributes.ViomiOperationMode}
      */
-    getAutoVacuumOperationMode() {
+    getVacuumOperationModeFromInstalledAccessories() {
         const dustbinAttribute = this.robot.state.getFirstMatchingAttribute({
             attributeClass: stateAttrs.AttachmentStateAttribute.name,
             attributeType: stateAttrs.AttachmentStateAttribute.TYPE.DUSTBIN
@@ -39,73 +54,211 @@ class ViomiBasicControlCapability extends BasicControlCapability {
     /**
      * Automatically set movement mode based on the previously computed operation mode
      *
+     * @private
      * @param {attributes.ViomiOperationMode} operationMode
      * @param {boolean} [outline] Vacuum along the edges
      * @returns {attributes.ViomiMovementMode}
      */
-    getAutoVacuumMovementMode(operationMode, outline) {
+    getVacuumMovementMode(operationMode, outline) {
         if (outline) {
             return attributes.ViomiMovementMode.OUTLINE;
         }
 
         switch (operationMode) {
             case attributes.ViomiOperationMode.MIXED:
-                return attributes.ViomiMovementMode.MOP_MOVES;
+                return attributes.ViomiMovementMode.VACUUM_AND_MOP;
             case attributes.ViomiOperationMode.MOP:
-                // doesn't support mop_moves with water-only tank
-                return attributes.ViomiMovementMode.ZONED_CLEAN_OR_MOPPING;
+                return attributes.ViomiMovementMode.MOP_NO_VACUUM;
             case attributes.ViomiOperationMode.VACUUM:
                 return attributes.ViomiMovementMode.NORMAL_CLEANING;
         }
     }
 
-    async start() {
-        const operationMode = this.getAutoVacuumOperationMode();
+    /**
+     * Adjust mop operation mode if it doesn't match the one previously set,
+     * The value should be retrieved using getVacuumOperationModeFromInstalledAccessories()
+     *
+     * @private
+     * @param {attributes.ViomiOperationMode} operationMode
+     * @returns {Promise<void>}
+     */
+    async ensureCleaningOperationMode(operationMode) {
         const curOperationMode = this.robot.state.getFirstMatchingAttributeByConstructor(
             stateAttrs.OperationModeStateAttribute
         );
         if (!curOperationMode || curOperationMode && curOperationMode.VALUE !== operationMode) {
             await this.robot.sendCommand("set_mop", [operationMode]);
         }
-
-        // TODO: find a way to provide this option
-        const outline = false;
-        const movementMode = this.getAutoVacuumMovementMode(operationMode, outline);
-        const additionalParamsLength = 0;
-
-        await this.robot.sendCommand("set_mode_withroom",
-            [movementMode, attributes.ViomiOperation.START, additionalParamsLength]);
     }
 
+    /**
+     * Start or resume cleaning the specified segment IDs, or the entire house.
+     *
+     * @public
+     * @param {attributes.ViomiOperation} operation Whether to start, stop or pause
+     * @param {Array<number>} [segmentIds] If specified, room IDs to clean. Else all house.
+     * @returns {Promise<void>}
+     */
+    async setModeWithSegments(operation, segmentIds) {
+        const operationMode = this.getVacuumOperationModeFromInstalledAccessories();
+        if (operation === attributes.ViomiOperation.START) {
+            await this.ensureCleaningOperationMode(operationMode);
+        }
+        const movementMode = this.getVacuumMovementMode(operationMode, false);
+
+        if (segmentIds === undefined || segmentIds === null) {
+            segmentIds = [];
+        }
+        await this.robot.sendCommand("set_mode_withroom",
+            [movementMode, operation, segmentIds.length].concat(segmentIds));
+
+        if (operation !== attributes.ViomiOperation.STOP) {
+            if (segmentIds.length > 0) {
+                this.robot.ephemeralState.lastOperationType = stateAttrs.StatusStateAttribute.FLAG.SEGMENT;
+            } else {
+                this.robot.ephemeralState.lastOperationType = stateAttrs.StatusStateAttribute.FLAG.NONE;
+            }
+            this.robot.ephemeralState.lastOperationSegmentsOrPos = segmentIds;
+        }
+    }
+
+    /**
+     * Start or resume cleaning around the specified location.
+     *
+     * @public
+     * @param {attributes.ViomiOperation} operation Whether to start, stop or pause
+     * @param {number} x
+     * @param {number} y
+     * @returns {Promise<void>}
+     */
+    async setModeCleanSpot(operation, x, y) {
+        if (operation === attributes.ViomiOperation.START) {
+            const operationMode = this.getVacuumOperationModeFromInstalledAccessories();
+            await this.ensureCleaningOperationMode(operationMode);
+        }
+
+        await this.robot.sendCommand("set_pointclean", [operation, x, y]);
+
+        if (operation !== attributes.ViomiOperation.STOP) {
+            this.robot.ephemeralState.lastOperationType = stateAttrs.StatusStateAttribute.FLAG.SPOT;
+            this.robot.ephemeralState.lastOperationSegmentsOrPos = [x, y];
+        }
+    }
+
+    /**
+     * Start, pause or resume vacuum after sending "set_zone". This can be used by ZoneCleaningCapability to start
+     * cleaning after sending the rectangular area, then later for pausing and resuming.
+     *
+     * @public
+     * @param {attributes.ViomiOperation} operation
+     * @returns {Promise<void>}
+     */
+    async setRectangularZoneMode(operation) {
+        if (operation === attributes.ViomiOperation.START) {
+            const operationMode = this.getVacuumOperationModeFromInstalledAccessories();
+            await this.ensureCleaningOperationMode(operationMode);
+        } else if (operation === attributes.ViomiOperation.PAUSE) {
+            Logger.warn("ViomiBasicControlCapability.setRectangularZoneMode should be used with PAUSE_RECTANGULAR_ZONE instead of pause!");
+            operation = attributes.ViomiOperation.PAUSE_RECTANGULAR_ZONE;
+        }
+        await this.robot.sendCommand("set_mode", [attributes.ViomiZoneCleaningCommand.CLEAN_ZONE, operation]);
+
+        if (operation !== attributes.ViomiOperation.STOP) {
+            this.robot.ephemeralState.lastOperationType = stateAttrs.StatusStateAttribute.FLAG.ZONE;
+            this.robot.ephemeralState.lastOperationSegmentsOrPos = [];
+        }
+    }
+
+    /**
+     * Start full house cleaning or resume previously paused operation.
+     *
+     * @returns {Promise<void>}
+     */
+    async start() {
+        const lastOperation = this.robot.ephemeralState.lastOperationType;
+        const lastOperationAdditionalParams = this.robot.ephemeralState.lastOperationAdditionalParams;
+
+        switch (lastOperation) {
+            // Resume
+            case stateAttrs.StatusStateAttribute.FLAG.NONE || stateAttrs.StatusStateAttribute.FLAG.SEGMENT:
+                await this.setModeWithSegments(attributes.ViomiOperation.START, lastOperationAdditionalParams);
+                break;
+            case stateAttrs.StatusStateAttribute.FLAG.ZONE:
+                await this.setRectangularZoneMode(attributes.ViomiOperation.START);
+                break;
+            case stateAttrs.StatusStateAttribute.FLAG.SPOT:
+                await this.setModeCleanSpot(attributes.ViomiOperation.START, lastOperationAdditionalParams[0], lastOperationAdditionalParams[1]);
+                break;
+            default:
+                await this.setModeWithSegments(attributes.ViomiOperation.START);
+                break;
+        }
+    }
+
+    /**
+     * Stop previously started operation, in a way that is not resumable.
+     *
+     * @returns {Promise<void>}
+     */
     async stop() {
         const statusAttribute = this.robot.state.getFirstMatchingAttributeByConstructor(
             stateAttrs.StatusStateAttribute
         );
+        const lastOperation = this.robot.ephemeralState.lastOperationType;
         if (statusAttribute && statusAttribute.VALUE === stateAttrs.StatusStateAttribute.VALUE.RETURNING) {
             // With the "stop returning" command as opposed to the common "stop" the voice provides the correct feedback
             await this.robot.sendCommand("set_charge", [0]);
+        } else if (lastOperation === stateAttrs.StatusStateAttribute.FLAG.SPOT) {
+            await this.setModeCleanSpot(attributes.ViomiOperation.STOP, 0, 0);
         } else if (statusAttribute && statusAttribute.VALUE === stateAttrs.StatusStateAttribute.VALUE.CLEANING) {
-            await this.robot.sendCommand("set_mode", [3, 0]);
+            await this.setRectangularZoneMode(attributes.ViomiOperation.STOP);
         } else {
             await this.robot.sendCommand("set_mode", [attributes.ViomiOperation.STOP]);
         }
+        this.robot.ephemeralState.lastOperationType = null;
+        this.robot.ephemeralState.lastOperationSegmentsOrPos = [];
     }
 
-    // TODO: test
+    /**
+     * Pause the current operation in a way that can be later resumed by running start().
+     *
+     * @returns {Promise<void>}
+     */
     async pause() {
-        const operationMode = this.getAutoVacuumOperationMode();
-        const outline = false;
-        const movementMode = this.getAutoVacuumMovementMode(operationMode, outline);
-        const additionalParamsLength = 0;
+        const statusAttribute = this.robot.state.getFirstMatchingAttributeByConstructor(
+            stateAttrs.StatusStateAttribute
+        );
 
-        await this.robot.sendCommand("set_mode_withroom",
-            [movementMode, attributes.ViomiOperation.PAUSE, additionalParamsLength]);
+        let lastOperation = this.robot.ephemeralState.lastOperationType;
+        let lastOperationAdditionalParams = this.robot.ephemeralState.lastOperationAdditionalParams;
+
+        // We can't pause/resume cleaning if the requested position isn't saved
+        if ((lastOperation === stateAttrs.StatusStateAttribute.FLAG.SEGMENT || lastOperation === stateAttrs.StatusStateAttribute.FLAG.SPOT) &&
+            lastOperationAdditionalParams.length === 0) {
+
+            lastOperation = null;
+        }
+
+        // Pausing requires us to remember how we started cleaning. If we don't know it resuming won't work,
+        // therefore we just stop. Also, pausing "return to dock" is the same as stopping it
+        if (lastOperation === null || statusAttribute && statusAttribute.VALUE === stateAttrs.StatusStateAttribute.VALUE.RETURNING) {
+            await this.stop();
+            return;
+        }
+
+        if (lastOperation === stateAttrs.StatusStateAttribute.FLAG.SPOT) {
+            await this.setModeCleanSpot(attributes.ViomiOperation.PAUSE, lastOperationAdditionalParams[0], lastOperationAdditionalParams[1]);
+        } else if (lastOperation === stateAttrs.StatusStateAttribute.FLAG.ZONE) {
+            await this.setRectangularZoneMode(attributes.ViomiOperation.PAUSE_RECTANGULAR_ZONE);
+        } else {
+            await this.setModeWithSegments(attributes.ViomiOperation.PAUSE, lastOperationAdditionalParams);
+        }
     }
 
     async home() {
         // If the vacuum is docked and we try to dock it again, it will start making out with the dock until stopped.
-        const statusAttribute = this.robot.state.getFirstMatchingAttribute({
-            attributeClass: stateAttrs.StatusStateAttribute.name
+        const statusAttribute = this.robot.state.getFirstMatchingAttributeByConstructor({
+            attributeClass: stateAttrs.StatusStateAttribute
         });
 
         if (statusAttribute && statusAttribute.value === stateAttrs.StatusStateAttribute.VALUE.DOCKED) {
@@ -113,6 +266,8 @@ class ViomiBasicControlCapability extends BasicControlCapability {
         }
 
         await this.robot.sendCommand("set_charge", [1]);
+        this.robot.ephemeralState.lastOperationType = null;
+        this.robot.ephemeralState.lastOperationSegmentsOrPos = [];
     }
 }
 

--- a/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
@@ -25,7 +25,7 @@ class ViomiBasicControlCapability extends BasicControlCapability {
     /**
      * Automatically sets mop mode depending on what tools are currently installed
      *
-     * @private
+     * @public
      * @returns {attributes.ViomiOperationMode}
      */
     getVacuumOperationModeFromInstalledAccessories() {
@@ -78,7 +78,7 @@ class ViomiBasicControlCapability extends BasicControlCapability {
      * Adjust mop operation mode if it doesn't match the one previously set,
      * The value should be retrieved using getVacuumOperationModeFromInstalledAccessories()
      *
-     * @private
+     * @public
      * @param {attributes.ViomiOperationMode} operationMode
      * @returns {Promise<void>}
      */
@@ -154,10 +154,7 @@ class ViomiBasicControlCapability extends BasicControlCapability {
      * @returns {Promise<void>}
      */
     async setRectangularZoneMode(operation) {
-        if (operation === attributes.ViomiOperation.START) {
-            const operationMode = this.getVacuumOperationModeFromInstalledAccessories();
-            await this.ensureCleaningOperationMode(operationMode);
-        } else if (operation === attributes.ViomiOperation.PAUSE) {
+        if (operation === attributes.ViomiOperation.PAUSE) {
             Logger.warn("ViomiBasicControlCapability.setRectangularZoneMode should be used with PAUSE_RECTANGULAR_ZONE instead of pause!");
             operation = attributes.ViomiOperation.PAUSE_RECTANGULAR_ZONE;
         }

--- a/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
@@ -118,7 +118,7 @@ class ViomiBasicControlCapability extends BasicControlCapability {
             } else {
                 this.robot.ephemeralState.lastOperationType = stateAttrs.StatusStateAttribute.FLAG.NONE;
             }
-            this.robot.ephemeralState.lastOperationSegmentsOrPos = segmentIds;
+            this.robot.ephemeralState.lastOperationAdditionalParams = segmentIds;
         }
     }
 
@@ -141,7 +141,7 @@ class ViomiBasicControlCapability extends BasicControlCapability {
 
         if (operation !== attributes.ViomiOperation.STOP) {
             this.robot.ephemeralState.lastOperationType = stateAttrs.StatusStateAttribute.FLAG.SPOT;
-            this.robot.ephemeralState.lastOperationSegmentsOrPos = [x, y];
+            this.robot.ephemeralState.lastOperationAdditionalParams = [x, y];
         }
     }
 
@@ -165,7 +165,7 @@ class ViomiBasicControlCapability extends BasicControlCapability {
 
         if (operation !== attributes.ViomiOperation.STOP) {
             this.robot.ephemeralState.lastOperationType = stateAttrs.StatusStateAttribute.FLAG.ZONE;
-            this.robot.ephemeralState.lastOperationSegmentsOrPos = [];
+            this.robot.ephemeralState.lastOperationAdditionalParams = [];
         }
     }
 
@@ -180,7 +180,8 @@ class ViomiBasicControlCapability extends BasicControlCapability {
 
         switch (lastOperation) {
             // Resume
-            case stateAttrs.StatusStateAttribute.FLAG.NONE || stateAttrs.StatusStateAttribute.FLAG.SEGMENT:
+            case stateAttrs.StatusStateAttribute.FLAG.NONE:
+            case stateAttrs.StatusStateAttribute.FLAG.SEGMENT:
                 await this.setModeWithSegments(attributes.ViomiOperation.START, lastOperationAdditionalParams);
                 break;
             case stateAttrs.StatusStateAttribute.FLAG.ZONE:
@@ -205,18 +206,18 @@ class ViomiBasicControlCapability extends BasicControlCapability {
             stateAttrs.StatusStateAttribute
         );
         const lastOperation = this.robot.ephemeralState.lastOperationType;
-        if (statusAttribute && statusAttribute.VALUE === stateAttrs.StatusStateAttribute.VALUE.RETURNING) {
+        if (statusAttribute && statusAttribute.value === stateAttrs.StatusStateAttribute.VALUE.RETURNING) {
             // With the "stop returning" command as opposed to the common "stop" the voice provides the correct feedback
             await this.robot.sendCommand("set_charge", [0]);
         } else if (lastOperation === stateAttrs.StatusStateAttribute.FLAG.SPOT) {
             await this.setModeCleanSpot(attributes.ViomiOperation.STOP, 0, 0);
-        } else if (statusAttribute && statusAttribute.VALUE === stateAttrs.StatusStateAttribute.VALUE.CLEANING) {
+        } else if (statusAttribute && statusAttribute.value === stateAttrs.StatusStateAttribute.VALUE.CLEANING) {
             await this.setRectangularZoneMode(attributes.ViomiOperation.STOP);
         } else {
             await this.robot.sendCommand("set_mode", [attributes.ViomiOperation.STOP]);
         }
         this.robot.ephemeralState.lastOperationType = null;
-        this.robot.ephemeralState.lastOperationSegmentsOrPos = [];
+        this.robot.ephemeralState.lastOperationAdditionalParams = [];
     }
 
     /**
@@ -241,7 +242,7 @@ class ViomiBasicControlCapability extends BasicControlCapability {
 
         // Pausing requires us to remember how we started cleaning. If we don't know it resuming won't work,
         // therefore we just stop. Also, pausing "return to dock" is the same as stopping it
-        if (lastOperation === null || statusAttribute && statusAttribute.VALUE === stateAttrs.StatusStateAttribute.VALUE.RETURNING) {
+        if (lastOperation === null || statusAttribute && statusAttribute.value === stateAttrs.StatusStateAttribute.VALUE.RETURNING) {
             await this.stop();
             return;
         }
@@ -257,9 +258,9 @@ class ViomiBasicControlCapability extends BasicControlCapability {
 
     async home() {
         // If the vacuum is docked and we try to dock it again, it will start making out with the dock until stopped.
-        const statusAttribute = this.robot.state.getFirstMatchingAttributeByConstructor({
-            attributeClass: stateAttrs.StatusStateAttribute
-        });
+        const statusAttribute = this.robot.state.getFirstMatchingAttributeByConstructor(
+            stateAttrs.StatusStateAttribute
+        );
 
         if (statusAttribute && statusAttribute.value === stateAttrs.StatusStateAttribute.VALUE.DOCKED) {
             return;
@@ -267,7 +268,7 @@ class ViomiBasicControlCapability extends BasicControlCapability {
 
         await this.robot.sendCommand("set_charge", [1]);
         this.robot.ephemeralState.lastOperationType = null;
-        this.robot.ephemeralState.lastOperationSegmentsOrPos = [];
+        this.robot.ephemeralState.lastOperationAdditionalParams = [];
     }
 }
 

--- a/lib/robots/viomi/capabilities/ViomiCarpetModeControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiCarpetModeControlCapability.js
@@ -27,7 +27,7 @@ class ViomiCarpetModeControlCapability extends CarpetModeControlCapability {
     async isEnabled() {
         // Disclaimer: nasty
         // noinspection JSUnresolvedVariable
-        const state = this.carpetModeEnabled;
+        const state = this.robot.ephemeralState.carpetModeEnabled;
         if (state !== null && state !== undefined) {
             return state;
         }
@@ -42,13 +42,13 @@ class ViomiCarpetModeControlCapability extends CarpetModeControlCapability {
             for await (const line of lineReader) {
                 if (line.startsWith("m_carpet_turbo")) {
                     if (line.trim().endsWith("=1")) {
-                        this.carpetModeEnabled = true;
+                        this.robot.ephemeralState.carpetModeEnabled = true;
                     } else if (line.endsWith("=0")) {
-                        this.carpetModeEnabled = false;
+                        this.robot.ephemeralState.carpetModeEnabled = false;
                     } else {
                         break;
                     }
-                    return this.carpetModeEnabled;
+                    return this.robot.ephemeralState.carpetModeEnabled;
                 }
             }
         }
@@ -62,7 +62,7 @@ class ViomiCarpetModeControlCapability extends CarpetModeControlCapability {
      * @returns {Promise<void>}
      */
     async enable() {
-        this.carpetModeEnabled = true;
+        this.robot.ephemeralState.carpetModeEnabled = true;
         // 0: off, 1: medium, 2: turbo
         await this.robot.sendCommand("set_carpetturbo", [2], {});
     }
@@ -72,7 +72,7 @@ class ViomiCarpetModeControlCapability extends CarpetModeControlCapability {
      * @returns {Promise<void>}
      */
     async disable() {
-        this.carpetModeEnabled = false;
+        this.robot.ephemeralState.carpetModeEnabled = false;
         await this.robot.sendCommand("set_carpetturbo", [0], {});
     }
 }

--- a/lib/robots/viomi/capabilities/ViomiMapSegmentationCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiMapSegmentationCapability.js
@@ -1,6 +1,6 @@
+const BasicControlCapability = require("../../../core/capabilities/BasicControlCapability");
 const Logger = require("../../../Logger");
 const MapSegmentationCapability = require("../../../core/capabilities/MapSegmentationCapability");
-const BasicControlCapability = require("../../../core/capabilities/BasicControlCapability");
 
 const attributes = require("../ViomiCommonAttributes");
 

--- a/lib/robots/viomi/capabilities/ViomiMapSegmentationCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiMapSegmentationCapability.js
@@ -1,19 +1,29 @@
 const Logger = require("../../../Logger");
 const MapSegmentationCapability = require("../../../core/capabilities/MapSegmentationCapability");
+const BasicControlCapability = require("../../../core/capabilities/BasicControlCapability");
+
+const attributes = require("../ViomiCommonAttributes");
 
 /**
  * @extends MapSegmentationCapability<import("../ViomiValetudoRobot")>
  */
 class ViomiMapSegmentationCapability extends MapSegmentationCapability {
     /**
+     * @private
+     * @returns {import("./ViomiBasicControlCapability")}
+     */
+    getBasicControlCapability() {
+        return this.robot.capabilities[BasicControlCapability.TYPE];
+    }
+
+    /**
      * @param {Array<import("../../../entities/core/ValetudoMapSegment")>} segments
      * @returns {Promise<void>}
      */
     async executeSegmentAction(segments) {
-        const segmentIds = segments.map(segment => segment.id);
+        const segmentIds = segments.map(segment => parseInt(segment.id));
         Logger.trace("segments to clean: ", segmentIds);
-
-        await this.robot.sendCommand("set_mode_withroom", [0, 1, segmentIds.length, ...segmentIds], {});
+        await this.getBasicControlCapability().setModeWithSegments(attributes.ViomiOperation.START, segmentIds);
     }
 }
 

--- a/lib/robots/viomi/capabilities/ViomiZoneCleaningCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiZoneCleaningCapability.js
@@ -35,7 +35,7 @@ class ViomiZoneCleaningCapability extends ZoneCleaningCapability {
 
         Logger.trace("areas to clean: ", areas);
         await this.robot.sendCommand("set_zone", [areas.length].concat(areas), {});
-        const movementMode = attributes.ViomiMovementMode.ZONED_CLEAN_OR_MOPPING;
+        const movementMode = attributes.ViomiMovementMode.MOP_NO_VACUUM;
         const additionalParamsLength = 0;
 
         await this.robot.sendCommand("set_mode", [movementMode, attributes.ViomiOperation.START, additionalParamsLength]);

--- a/lib/robots/viomi/capabilities/ViomiZoneCleaningCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiZoneCleaningCapability.js
@@ -1,8 +1,8 @@
 const attributes = require("../ViomiCommonAttributes");
+const BasicControlCapability = require("../../../core/capabilities/BasicControlCapability");
 const Logger = require("../../../Logger");
 const ViomiMapParser = require("../ViomiMapParser");
 const ZoneCleaningCapability = require("../../../core/capabilities/ZoneCleaningCapability");
-const BasicControlCapability = require("../../../core/capabilities/BasicControlCapability");
 
 /**
  * @extends ZoneCleaningCapability<import("../ViomiValetudoRobot")>

--- a/lib/robots/viomi/capabilities/ViomiZoneCleaningCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiZoneCleaningCapability.js
@@ -2,11 +2,20 @@ const attributes = require("../ViomiCommonAttributes");
 const Logger = require("../../../Logger");
 const ViomiMapParser = require("../ViomiMapParser");
 const ZoneCleaningCapability = require("../../../core/capabilities/ZoneCleaningCapability");
+const BasicControlCapability = require("../../../core/capabilities/BasicControlCapability");
 
 /**
  * @extends ZoneCleaningCapability<import("../ViomiValetudoRobot")>
  */
 class ViomiZoneCleaningCapability extends ZoneCleaningCapability {
+    /**
+     * @private
+     * @returns {import("./ViomiBasicControlCapability")}
+     */
+    getBasicControlCapability() {
+        return this.robot.capabilities[BasicControlCapability.TYPE];
+    }
+
     /**
      * @param {Array<import("../../../entities/core/ValetudoZone")>} valetudoZones
      * @returns {Promise<void>}
@@ -14,7 +23,7 @@ class ViomiZoneCleaningCapability extends ZoneCleaningCapability {
     async start(valetudoZones) {
         let areas = [];
 
-        valetudoZones.forEach( zone => {
+        valetudoZones.forEach(zone => {
             const pA = ViomiMapParser.positionToViomi(zone.points.pA.x, zone.points.pA.y);
             const pC = ViomiMapParser.positionToViomi(zone.points.pC.x, zone.points.pC.y);
 
@@ -35,10 +44,7 @@ class ViomiZoneCleaningCapability extends ZoneCleaningCapability {
 
         Logger.trace("areas to clean: ", areas);
         await this.robot.sendCommand("set_zone", [areas.length].concat(areas), {});
-        const movementMode = attributes.ViomiMovementMode.MOP_NO_VACUUM;
-        const additionalParamsLength = 0;
-
-        await this.robot.sendCommand("set_mode", [movementMode, attributes.ViomiOperation.START, additionalParamsLength]);
+        await this.getBasicControlCapability().setRectangularZoneMode(attributes.ViomiOperation.START);
     }
 
     /**

--- a/lib/robots/viomi/capabilities/ViomiZoneCleaningCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiZoneCleaningCapability.js
@@ -22,6 +22,14 @@ class ViomiZoneCleaningCapability extends ZoneCleaningCapability {
      */
     async start(valetudoZones) {
         let areas = [];
+        const basicControlCap = this.getBasicControlCapability();
+
+        const operationMode = basicControlCap.getVacuumOperationModeFromInstalledAccessories();
+        await basicControlCap.ensureCleaningOperationMode(operationMode);
+
+        // The app sends set_uploadmap [1] when the "draw area" button is pressed.
+        // The robot seems to end up in a weird state if we don't do this.
+        await this.robot.sendCommand("set_uploadmap", [1]);
 
         valetudoZones.forEach(zone => {
             const pA = ViomiMapParser.positionToViomi(zone.points.pA.x, zone.points.pA.y);
@@ -44,7 +52,7 @@ class ViomiZoneCleaningCapability extends ZoneCleaningCapability {
 
         Logger.trace("areas to clean: ", areas);
         await this.robot.sendCommand("set_zone", [areas.length].concat(areas), {});
-        await this.getBasicControlCapability().setRectangularZoneMode(attributes.ViomiOperation.START);
+        await basicControlCap.setRectangularZoneMode(attributes.ViomiOperation.START);
     }
 
     /**


### PR DESCRIPTION
## Type of change

Type A:
- [X] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation

# Description (Type A)

This PR attempts to fix a bunch of issues previously reported, explicitly or implicitly:

Closes #731 

The new basic control capability implementation now remembers what cleaning command was last sent, since it is required later for pausing, stopping and resuming. We have to remember it ourselves since there doesn't seem to be a way to retrieve it from the vacuum state.

This persistence expands on the previously introduced dynamic robot object property for the carpet turbo mode by replacing it with an `ephemeralState` object. This object now stores the last carpet turbo mode and the last cleaning operation details.

This implies that other capabilities that intend to perform cleaning jobs MUST use the methods provided by this cap instead of sending them themselves, to ensure that the state is remembered and to avoid multiple access to the same values. This can be accomplished using a few new public methods which closely match the vacuum counterparts.

The ZoneCleaning capability will be adapted to this new implementation.

----
### EDIT

The implementation is complete but it's too late to test it, please don't merge as long as it's marked as draft.