### PR TITLE
viomi: Fix "Unknown water grade"

### DIFF
--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -113,7 +113,6 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
             robot: this
         }));
 
-
         this.state.upsertFirstMatchingAttribute(new stateAttrs.AttachmentStateAttribute({
             type: stateAttrs.AttachmentStateAttribute.TYPE.DUSTBIN,
             attached: false
@@ -285,6 +284,16 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
                 type: stateAttrs.IntensityStateAttribute.TYPE.FAN_SPEED,
                 value: matchingFanSpeed,
                 customValue: matchingFanSpeed === stateAttrs.IntensityStateAttribute.VALUE.CUSTOM ? data["suction_grade"] : undefined
+            }));
+        }
+
+        if (data["water_grade"] !== undefined) {
+            let matchingWaterGrade = Object.keys(this.fanSpeeds).find(key => this.waterGrades[key] === data["water_grade"]);
+
+            this.state.upsertFirstMatchingAttribute(new stateAttrs.IntensityStateAttribute({
+                type: stateAttrs.IntensityStateAttribute.TYPE.WATER_GRADE,
+                value: matchingWaterGrade,
+                customValue: matchingWaterGrade === stateAttrs.IntensityStateAttribute.VALUE.CUSTOM ? data["water_grade"] : undefined
             }));
         }
 

--- a/lib/robots/viomi/capabilities/ViomiWaterUsageControlCapability.js
+++ b/lib/robots/viomi/capabilities/ViomiWaterUsageControlCapability.js
@@ -7,7 +7,7 @@ class ViomiWaterUsageControlCapability extends WaterUsageControlCapability {
     /**
      * @returns {Array<string>}
      */
-    getWaterUsagePresets() {
+    getPresets() {
         return this.presets.map(p => p.name);
     }
 
@@ -15,7 +15,7 @@ class ViomiWaterUsageControlCapability extends WaterUsageControlCapability {
      * @param {string} preset
      * @returns {Promise<void>}
      */
-    async setWaterUsagePreset(preset) {
+    async setIntensity(preset) {
         const matchedPreset = this.presets.find(p => p.name === preset);
 
         if (matchedPreset) {
@@ -24,7 +24,6 @@ class ViomiWaterUsageControlCapability extends WaterUsageControlCapability {
             throw new Error("Invalid Preset");
         }
     }
-
 }
 
 module.exports = ViomiWaterUsageControlCapability;


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
# Description (Type A)

The Viomi water usage capability was stuck to the old implementation not based on IntensityPreset. Somehow this wasn't caught by the linter.

This fixes the method names in the capability and ensures the correct status value is set when parsing the status message.