### PR TITLE
viomi: Fix water grade controlling fan speed instead

### DIFF
--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -54,10 +54,7 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
 
         this.registerCapability(new capabilities.ViomiWaterUsageControlCapability({
             robot: this,
-            presets: Object.keys(this.waterGrades).map(k => new IntensityPreset({
-                name: k,
-                value: this.fanSpeeds[k]
-            }))
+            presets: Object.keys(this.waterGrades).map(k => new IntensityPreset({name: k, value: this.waterGrades[k]}))
         }));
 
         this.registerCapability(new capabilities.ViomiWifiConfigurationCapability({


### PR DESCRIPTION
Fixes issue reported in Telegram where the water grade control changes fan speed instead.

The command for both is the same on Viomi and the water grade control was using the fan speed presets.