### PR TITLE
viomi: Increase timeout for set_timezone

### DIFF
--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -149,12 +149,12 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
         super.onCloudConnected();
 
         setTimeout(() => {
-            this.sendCommand("get_prop", ["timezone"]).then((res) => {
+            this.sendCommand("get_prop", ["timezone"], {timeout: 12000}).then((res) => {
                 if (res.length > 0) {
                     const timezone = res[0];
                     if (timezone !== 0) {
                         // Set timezone to UTC
-                        this.sendCommand("set_timezone", [0]).then(_ => {
+                        this.sendCommand("set_timezone", [0], {timeout: 12000}).then(_ => {
                             Logger.info("Viomi timezone adjusted to UTC");
                         });
                     }


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
 
<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)
It looks like sometimes set_timezone takes ~1s to execute in some cases.
We have time. Increase timeout so it doesn't take the entire connection down.

EDIT:
Actually I looked at the guy's logs better and it seems like `set_timezone` takes 10 seconds. I gave it 12 sec timeout.

Closes #799
