### PR TITLE
fix(vendor.roborock): do not send empty layers

### DIFF
--- a/lib/entities/map/MapEntity.js
+++ b/lib/entities/map/MapEntity.js
@@ -15,7 +15,7 @@ class MapEntity extends SerializableEntity {
     constructor(options) {
         super(options);
 
-        if (options.points.length % 2 !== 0) {
+        if (options.points.length === 0 || options.points.length % 2 !== 0) {
             throw new Error("Invalid points array");
         }
 

--- a/lib/entities/map/MapLayer.js
+++ b/lib/entities/map/MapLayer.js
@@ -22,8 +22,12 @@ class MapLayer extends SerializableEntity {
      */
     constructor(options) {
         super(options);
-        if (options.pixels.length % 2 !== 0) {
+        if (options.pixels.length === 0 || options.pixels.length % 2 !== 0) {
             throw new Error("Invalid pixels array");
+        }
+
+        if (!options.pixels.every(e => Number.isInteger(e))) {
+            throw new Error("Only integer coordinates are allowed");
         }
 
         this.type = options.type;

--- a/lib/robots/roborock/RRMapParser.js
+++ b/lib/robots/roborock/RRMapParser.js
@@ -326,20 +326,33 @@ class RRMapParser {
      */
     static POST_PROCESS_BLOCKS(metaData, blocks) {
         if (blocks[BlockTypes.IMAGE] && blocks[BlockTypes.IMAGE].pixels) { //We need the image to flip everything else correctly
-            const layers = [
-                new Map.MapLayer({
-                    pixels: blocks[BlockTypes.IMAGE].pixels.floor,
-                    type: Map.MapLayer.TYPE.FLOOR
-                }),
-                new Map.MapLayer({
-                    pixels: blocks[BlockTypes.IMAGE].pixels.obstacle_strong,
-                    type: Map.MapLayer.TYPE.WALL
-                })
-            ];
+            const layers = [];
             const entities = [];
             let angle = null;
 
+            if (blocks[BlockTypes.IMAGE].pixels.floor.length > 0) {
+                layers.push(
+                    new Map.MapLayer({
+                        pixels: blocks[BlockTypes.IMAGE].pixels.floor,
+                        type: Map.MapLayer.TYPE.FLOOR,
+                    })
+                );
+            }
+
+            if (blocks[BlockTypes.IMAGE].pixels.obstacle_strong.length > 0) {
+                layers.push(
+                    new Map.MapLayer({
+                        pixels: blocks[BlockTypes.IMAGE].pixels.obstacle_strong,
+                        type: Map.MapLayer.TYPE.WALL,
+                    })
+                );
+            }
+
             Object.keys(blocks[BlockTypes.IMAGE].segments).forEach(k => {
+                if (blocks[BlockTypes.IMAGE].segments[k].length === 0) {
+                    return;
+                }
+
                 const segmentId = parseInt(k);
                 let isActive = false;
 
@@ -387,7 +400,6 @@ class RRMapParser {
                     points: points,
                     type: Map.PathMapEntity.TYPE.PATH
                 }));
-
             }
 
             if (blocks[BlockTypes.GOTO_PREDICTED_PATH]) {


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)

# Description (Type A)
Roborock sends empty floor layer with dimensions min and max set to 0, which causes Lovelace Valetudo Map Card to be unable to properly create bounds for the map.
This removes these empty layers.