### PR TITLE
viomi: Raise default miIO timeout

### DIFF
--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -148,6 +148,20 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
         this.tokenFilePath = ViomiValetudoRobot.TOKEN_FILE_PATH;
     }
 
+    sendCommand(method, args = [], options = {}) {
+        options = Object.assign({
+            timeout: 2000,
+        }, options);
+        return super.sendCommand(method, args, options);
+    }
+
+    sendCloud(msg, options = {}) {
+        options = Object.assign({
+            timeout: 2000,
+        }, options);
+        return super.sendCloud(msg, options);
+    }
+
     onCloudConnected() {
         super.onCloudConnected();
 

--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -148,6 +148,18 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
         this.tokenFilePath = ViomiValetudoRobot.TOKEN_FILE_PATH;
     }
 
+    /**
+     * Sends a {'method': method, 'params': args} message to the robot.
+     * Uses the cloud socket if available or falls back to the local one.
+     *
+     * @public
+     * @param {string} method
+     * @param {object|Array} args
+     * @param {object} options
+     * @param {number=} options.retries
+     * @param {number=} options.timeout custom timeout in milliseconds
+     * @returns {Promise<object>}
+     */
     sendCommand(method, args = [], options = {}) {
         options = Object.assign({
             timeout: 2000,
@@ -155,6 +167,15 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
         return super.sendCommand(method, args, options);
     }
 
+    /**
+     * Sends a json object to cloud socket.
+     *
+     * @public
+     * @param {object} msg JSON object to send.
+     * @param {object} options
+     * @param {number=} options.timeout custom timeout in milliseconds
+     * @returns {Promise<object>}
+     */
     sendCloud(msg, options = {}) {
         options = Object.assign({
             timeout: 2000,


### PR DESCRIPTION
Viomi is slow :/

## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  

Viomi gets a shitload of random uncaught rejections caused by it being too slow replying to a lot of commands, especially during the initial connection.

It does reply eventually, it just needs patience. This raises the default timeout to 2 seconds.