### PR TITLE
viomi: Fix map issues (hopefully)

### DIFF
--- a/assets/kaitai_structs/viomi_map_file.ksy
+++ b/assets/kaitai_structs/viomi_map_file.ksy
@@ -1,0 +1,392 @@
+meta:
+  id: viomimap
+  title: Viomi vacuum map format
+  license: CC-BY-SA-4.0
+  ks-version: 0.8
+  endian: le
+  bit-endian: le
+
+seq:
+  - id: feature_flags
+    type: u4
+
+  - id: map_id
+    type: u4
+
+  - id: robot_status
+    size: 0x28
+    if: feature_flags & 0b000000000000001 != 0
+
+  - id: image
+    type: map_image_tlv
+    if: feature_flags & 0b000000000000010 != 0
+
+  - id: history
+    type: history_tlv
+    if: feature_flags & 0b000000000000100 != 0
+
+  - id: charger_pos
+    type: charger_position
+    if: feature_flags & 0b000000000001000 != 0
+
+  - id: restrictions
+    type: restrictions_tlv
+    if: feature_flags & 0b000000000010000 != 0
+
+  - id: areas
+    type: clean_areas_tlv
+    if: feature_flags & 0b000000000100000 != 0
+
+  - id: navigate_target
+    type: navigate_target
+    if: feature_flags & 0b000000001000000 != 0
+
+  - id: realtime_pose
+    type: realtime_pose
+    if: feature_flags & 0b000000010000000 != 0
+
+  - id: rooms
+    type: rooms_tlv
+    if: feature_flags & 0b000100000000000 != 0
+
+
+types:
+  tag_len:
+    seq:
+      - id: tag
+        type: u8
+
+      - id: len
+        type: u4
+
+  coordinate:
+    seq:
+      - id: x_crappy
+        type: f4
+
+      - id: y_crappy
+        type: f4
+
+    instances:
+      x:
+        value: ((20 + x_crappy) * 100).to_i
+
+      y:
+        value: (4000 - (20 + y_crappy) * 100).to_i
+
+      is_unknown:
+        value: x_crappy == 1100 or y_crappy == 1100
+
+  coordinate_nobs:
+    seq:
+      - id: x_crappy
+        type: f4
+
+      - id: y_crappy
+        type: f4
+
+    instances:
+      x:
+        value: x_crappy.to_i
+      y:
+        value: (4000 - y_crappy).to_i
+
+
+  area:
+    seq:
+      - id: vertices
+        type: coordinate_nobs
+        repeat: expr
+        repeat-expr: 4
+
+  line:
+    seq:
+      - id: p1
+        type: coordinate_nobs
+
+      - id: p2
+        type: coordinate_nobs
+
+  string:
+    seq:
+      - id: len
+        type: u1
+
+      - id: string
+        type: str
+        size: len
+        encoding: UTF-8
+
+  map_image_tlv:
+    seq:
+      - id: tlv
+        type: tag_len
+
+      - id: height
+        type: u4
+
+      - id: width
+        type: u4
+
+      - id: unk2
+        size: 20
+
+      - id: pixels
+        size: height * height
+        if: height * height >= 0
+
+  history_position:
+    seq:
+      - id: unk1
+        size: 1
+
+      - id: pos
+        type: coordinate
+
+  history_tlv:
+    seq:
+      - id: tlv
+        type: tag_len
+
+      - id: values
+        type: history_position
+        repeat: expr
+        repeat-expr: tlv.len
+
+  charger_position:
+    seq:
+      - id: unk1
+        type: u4
+
+      - id: position
+        type: coordinate
+
+      - id: orientation
+        type: f4
+
+  virtual_wall:
+    seq:
+      - id: line
+        type: line
+
+      - id: unk1
+        size: 16
+
+
+  restriction_item_tlv:
+    seq:
+      - id: tlv
+        type: tag_len
+
+      - id: area
+        type: area
+
+      - id: unk1
+        size: 48
+
+    instances:
+      is_area:
+        value: tlv.len == 4
+      is_wall:
+        value: tlv.len == 2
+
+  restrictions_tlv:
+    seq:
+      - id: tlv
+        type: tag_len
+
+      - id: restrictions
+        type: restriction_item_tlv
+        repeat: expr
+        repeat-expr: tlv.len
+
+  area_tlv:
+    seq:
+      - id: tlv
+        type: tag_len
+
+      - id: area
+        type: area
+
+      - id: unk1
+        size: 48
+
+  clean_areas_tlv:
+    seq:
+      - id: tlv
+        type: tag_len
+
+      - id: areas
+        type: area_tlv
+        repeat: expr
+        repeat-expr: tlv.len
+
+  navigate_target:
+    seq:
+      - id: unk1
+        type: u8
+
+      - id: target
+        type: coordinate
+
+      - id: unk2
+        type: u4
+
+  realtime_pose:
+    seq:
+      - id: unk1
+        size: 9
+
+      - id: pose
+        type: coordinate
+
+      - id: unk2
+        type: u4
+
+  map:
+    seq:
+      - id: name
+        type: string
+
+      - id: args
+        type: u4
+
+  room:
+    seq:
+      - id: id
+        type: u1
+
+      - id: name_len
+        type: u1
+
+      - id: name
+        type: str
+        size: name_len
+        encoding: UTF-8
+
+      - id: null_term
+        type: u1
+
+      - id: unk1
+        type: u8
+
+  # TODO: reverse-engineer properly
+  rooms2:
+    seq:
+      - id: first_b_of_tag
+        type: u1
+
+      - id: rest_of_tag
+        size: 3
+
+      - id: tag1
+        type: u4
+
+      - id: len
+        type: u4
+
+      - id: unk_room_data
+        size: 92
+        repeat: expr
+        repeat-expr: len
+
+  rooms_flag:
+    seq:
+      - id: room_id
+        type: u1
+
+      - id: some_flag
+        type: u1
+
+  pose_point:
+    seq:
+      - id: x_raw
+        type: u2
+
+      - id: y_raw
+        type: u2
+
+      - id: unk1
+        type: u1
+
+    instances:
+      x:
+        value: x_raw * 5
+      y:
+        value: 4000 - y_raw * 5
+
+  pose:
+    seq:
+      - id: room_id
+        type: u4
+
+      - id: elements
+        type: u4
+
+      - id: points
+        type: pose_point
+        repeat: expr
+        repeat-expr: elements
+
+  rooms_tlv:
+    seq:
+      # It actually doesn't seem to be TLV but whatever
+      - id: not_a_tlv
+        type: tag_len
+
+      - id: maps
+        type: map
+        repeat: until
+        repeat-until: _.args <= 1
+
+      - id: rooms_len
+        type: u4
+
+      - id: rooms
+        type: room
+        repeat: expr
+        repeat-expr: rooms_len
+
+      - id: unk1
+        size: 6
+
+      - id: rooms2
+        type: rooms2
+        #if: rooms_len != 0
+
+      - id: unk_pose_stuff_len
+        type: u4
+
+      - id: room_flags
+        type: rooms_flag
+        repeat: expr
+        repeat-expr: unk_pose_stuff_len
+
+      # Hack - I wasn't able to understand this structure, it has a variable length that seems grow together with the
+      # number of segments, but not linearly, exponentially or anything else.
+      # This simply tries to eat up as many bytes until the start of the known tag value is found. Note that the tag
+      # varies from vacuum to vacuum
+      - id: unk2
+        type: u1
+        repeat: until
+        repeat-until: _ == rooms2.first_b_of_tag
+
+      - id: some_header_ignore
+        size: 3
+
+      - id: unk_pose_stuff
+        type: u8
+        repeat: expr
+        repeat-expr: 6
+
+      - id: unk3
+        size: 3
+
+      - id: pose_len
+        type: u4
+
+      - id: pose
+        type: pose
+        repeat: expr
+        repeat-expr: pose_len
+

--- a/lib/robots/viomi/ViomiMapParser.js
+++ b/lib/robots/viomi/ViomiMapParser.js
@@ -33,6 +33,16 @@ class ViomiMapParser {
     }
 
     /**
+     * Retrieves n bytes from current offsets without advancing
+     *
+     * @param {number} n
+     * @returns {Buffer}
+     */
+    peek(n) {
+        return this.buf.slice(this.offset, this.offset + n);
+    }
+
+    /**
      * @param {Buffer} buf
      * @param {number} offset
      * @returns {Array<number>} x,y-position in mm format
@@ -187,9 +197,7 @@ class ViomiMapParser {
             //v7 example: e35a185e00000001
             this.take(8, "unknown8");
             this.parseRooms();
-            // more stuff i don't understand
-            this.take(50, "unknown50");
-            this.take(5, "unknown5");
+
             this.points = [];
             try {
                 this.parsePose();
@@ -286,7 +294,6 @@ class ViomiMapParser {
 
                     mapContents.path.points[mapContents.path.points.length - 2] -
                     mapContents.path.points[mapContents.path.points.length - 4]
-
                 ) * 180 / Math.PI) + 90) % 360; //TODO: No idea why
             }
         }
@@ -370,6 +377,9 @@ class ViomiMapParser {
     }
 
     parsePose() {
+        this.take(8 * 6, "unknown pose stuff");
+        this.take(3, "unknown3");
+
         let length = this.take(4, "pose length").readUInt32LE(0);
         for (let i = 0; i < length; i++) {
             let roomId = this.buf.readUInt32LE(this.offset);
@@ -434,25 +444,31 @@ class ViomiMapParser {
         this.take(6, "unknown");
 
         if (length) { // TODO: unclear what the condition is
-            this.take(12, "rooms2head");
+            const rooms2header = this.take(8, "rooms2head");
             const rooms2length = this.take(4, "rooms2 length").readUInt32LE(0);
 
-            //RoomData looks like this:
+            for (let i = 0; i < rooms2length; i++) {
+                this.take(92, "unknown room data");
+            }
+
+            const unkLength = this.take(4, "unk length").readUInt32LE(0);
+
+            //RoomFlags looks like this:
             //0a010b010c010d010e01
             //Repeated for every room there is
-            this.take(rooms2length * 2, "room data");
-            let x = this.take(4, "unknown2").readUInt32BE(0); // big endian!!!
+            this.take(unkLength * 2, "room data");
 
-            let index = [45, 21, 12][x];
+            // Hack - I wasn't able to understand this structure, it has a variable length that seems grow together with the
+            // number of segments, but not linearly, exponentially or anything else.
+            // This simply tries to eat up as many bytes until the start of the known tag value is found. Note that the tag
+            // varies from vacuum to vacuum
+            let takenBytes;
+            do {
+                takenBytes = this.peek(4);
+                this.offset += 1;
+            } while (Buffer.compare(takenBytes, rooms2header.slice(0, 4)));
 
-            if (index) {
-                this.take([45, 21, 12][x], "unknown");
-            } else {
-                //TODO: HACK
-                //While this is certainly a logic error somewhere else,
-                //this seems to fix map parsing for v6 Version 34 for now
-                this.offset -= 3;
-            }
+            this.take(3, "rest of tag");
         }
     }
 
@@ -578,13 +594,6 @@ function asFloat(buf) {
 ViomiMapParser.MAX_MAP_HEIGHT = ViomiMapParser.convertFloat(20); // 4000
 
 ViomiMapParser.POSITION_UNKNOWN = 1100;
-
-
-
-
-
-
-
 
 
 module.exports = ViomiMapParser;


### PR DESCRIPTION
This PR includes my Kaitai struct for the Viomi map, + some fixes I was able to figure out thanks to it.

The previous map implementation was expecting the segment outlines to be at an earlier offset, causing it to read garbage as the number of segments and eventually end up overflowing.

I was not able to figure out the mysterious chunk yet, but since all data seems to loosely stick to a TLV (tag-length-value) format, and since the tag seems to always be an 8 byte value, with the first 4 byte being always the same for maps generated by the same device, I just save these 4 bytes and then use them to scan for the next section.

----

## Testing

Viomi owners, please test this and let me know if it works for you. If you still get no map or you see map parsing-related errors in the log, please:

- Edit the config file, under `debug` enable `enableDebugCapability`.
  ```json
  [...]
    "debug": {
      "memoryStatInterval": false,
      "enableDebugCapability": true
    }
  [...]
  ```
- Restart valetudo
- Install valetudo with the changes from this PR
  ```sh
  git clone https://github.com/Depau/Valetudo.git
  cd Valetudo
  git checkout viomi-map
  # Do your thing, build and send it to the robot
  ```
- Use the following script to fetch the map from Valetudo
- Send it to me on Telegram together with
  - A screenshot of the map
  - The number of segments
  - Firmware version and vacuum model as reported by the script
  - The status of the device when the map was retrieved (docked, idle, docked/idle but after a recent clean)
  - If possible, please also send a second map sample right after rebooting the device while it's idle and docked

Script:
```sh
#!/bin/sh
source /etc/YMsave01/os-release
source /etc/miio/device.conf
echo "Firmware version: $VIOMI_VERSION"
echo "Vacuum model: $model"

nc 127.0.0.1 80 > /mnt/UDISK/map.json << EOF
PUT /api/v2/robot/capabilities/DebugCapability
Host: localhost
Content-Type: application/json
Connection: close
Content-Length: 22

{"action": "last_map"}
EOF
echo "Downloaded last map to /mnt/UDISK/map.json"

nc 127.0.0.1 80 > /mnt/UDISK/map_err.json << EOF
PUT /api/v2/robot/capabilities/DebugCapability
Host: localhost
Content-Type: application/json
Connection: close
Content-Length: 26

{"action": "last_err_map"}
EOF
echo "Downloaded last error map to /mnt/UDISK/map_err.json"
```



```

