### PR TITLE
Typo fix for waterGrades Object key

### DIFF
--- a/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/lib/robots/viomi/ViomiValetudoRobot.js
@@ -354,7 +354,7 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
         }
 
         if (data["water_grade"] !== undefined) {
-            let matchingWaterGrade = Object.keys(this.fanSpeeds).find(key => this.waterGrades[key] === data["water_grade"]);
+            let matchingWaterGrade = Object.keys(this.waterGrades).find(key => this.waterGrades[key] === data["water_grade"]);
 
             this.state.upsertFirstMatchingAttribute(new stateAttrs.IntensityStateAttribute({
                 type: stateAttrs.IntensityStateAttribute.TYPE.WATER_GRADE,


### PR DESCRIPTION
As discussed on Telegram with @Depau , this line should've been replaced already. 
It should be a non breaking change.