### PR TITLE
fix(mqtt): Handle nested reconfiguration

### DIFF
--- a/lib/mqtt/MqttController.js
+++ b/lib/mqtt/MqttController.js
@@ -311,7 +311,9 @@ class MqttController {
                     this.startAutorefreshService();
                     Logger.info("MQTT configured");
                 }).then(() => {
-                    this.robotHandle.refresh().then();
+                    this.setState(HomieCommonAttributes.STATE.READY).then(() => {
+                        this.robotHandle.refresh().then();
+                    });
                 });
             });
 
@@ -479,6 +481,15 @@ class MqttController {
         };
         if (options !== undefined) {
             Object.assign(reconfOptions, options);
+        }
+
+        // Nested reconfiguration, may occur i.e. if consumables are already available during first configuration.
+        // In this case, just force the target state to be init as well.
+        // on("connect") will handle the special case where this is triggered on first connection.
+        if (this.state === reconfOptions.reconfigState && this.state === HomieCommonAttributes.STATE.INIT &&
+            reconfOptions.targetState === HomieCommonAttributes.STATE.READY) {
+
+            reconfOptions.targetState = HomieCommonAttributes.STATE.INIT;
         }
 
         try {


### PR DESCRIPTION
Please don't merge this yet, I haven't tested it.

I just realized this may cause weird issues difficult to troubleshoot.

This handles the case in which `reconfigured()` is called inside another `reconfigure()` call - at the moment the inner reconfigure will set the status to `ready` on return, making any subsequent reconfig operations in the outer call fail.