### PR TITLE
feat(core): Add RobotSpecificToggleCapability

### DIFF
--- a/lib/core/capabilities/RobotSpecificToggleCapability.js
+++ b/lib/core/capabilities/RobotSpecificToggleCapability.js
@@ -1,0 +1,63 @@
+const Capability = require("./Capability");
+const NotImplementedError = require("../NotImplementedError");
+
+/**
+ * @template {import("../ValetudoRobot")} T
+ * @extends Capability<T>
+ */
+class RobotSpecificToggleCapability extends Capability {
+    /**
+     * Returns the toggle types this robot supports
+     *
+     * @abstract
+     * @returns {Array<string>}
+     */
+    getSupportedToggleTypes() {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * This function updates and returns the supported robot specific toggles and their values.
+     *
+     * @returns {Promise<Array<import("../../entities/state/attributes/RobotSpecificToggleStateAttribute")>>}
+     */
+    async getToggles() {
+        const result = [];
+        for (const type of this.getSupportedToggleTypes()) {
+            result.push(await this.getToggle({type: type}));
+        }
+        return result;
+    }
+
+    /**
+     * This function updates and returns one supported robot specific toggle and its values
+     *
+     * @abstract
+     * @param {object} options
+     * @param {string} options.type
+     * @return {Promise<import("../../entities/state/attributes/RobotSpecificToggleStateAttribute")>}
+     */
+    async getToggle(options) {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * Sets a robot toggle to a specific value.
+     *
+     * @param {object} options
+     * @param {string} options.type
+     * @param {boolean} options.value
+     * @returns {Promise<void>}
+     */
+    async setToggle(options) {
+        throw new NotImplementedError();
+    }
+
+    getType() {
+        return RobotSpecificToggleCapability.TYPE;
+    }
+}
+
+RobotSpecificToggleCapability.TYPE = "RobotSpecificToggleCapability";
+
+module.exports = RobotSpecificToggleCapability;

--- a/lib/core/capabilities/index.js
+++ b/lib/core/capabilities/index.js
@@ -17,6 +17,7 @@ module.exports = {
     MapSegmentationCapability: require("./MapSegmentationCapability"),
     MapSnapshotCapability: require("./MapSnapshotCapability"),
     PersistentMapControlCapability: require("./PersistentMapControlCapability"),
+    RobotSpecificToggleCapability: require("./RobotSpecificToggleCapability"),
     SensorCalibrationCapability: require("./SensorCalibrationCapability"),
     SpeakerTestCapability: require("./SpeakerTestCapability"),
     SpeakerVolumeControlCapability: require("./SpeakerVolumeControlCapability"),

--- a/lib/entities/state/attributes/RobotSpecificToggleStateAttribute.js
+++ b/lib/entities/state/attributes/RobotSpecificToggleStateAttribute.js
@@ -1,0 +1,32 @@
+const StateAttribute = require("./StateAttribute");
+
+/**
+ * Represents a robot specific toggle.
+ * Having it in the state makes it easier to propagate the changes to MQTT. However, front-ends should use
+ * RobotSpecificToggleCapability.getToggles() to ensure they get up-to-date values.
+ */
+class RobotSpecificToggleStateAttribute extends StateAttribute {
+    /**
+     * @param {object} options
+     * @param {RobotSpecificToggleStateAttributeType} options.type
+     * @param {boolean} options.value
+     * @param {object} [options.metaData]
+     */
+    constructor(options) {
+        super(options);
+
+        this.type = options.type;
+        this.value = options.value;
+    }
+}
+
+/**
+ *  @typedef {string} RobotSpecificToggleStateAttributeType
+ *  @enum {string}
+ */
+RobotSpecificToggleStateAttribute.TYPE = Object.freeze({
+    LEDS: "leds",
+    REPEAT_CLEANING: "repeat_cleaning",
+});
+
+module.exports = RobotSpecificToggleStateAttribute;

--- a/lib/entities/state/attributes/index.js
+++ b/lib/entities/state/attributes/index.js
@@ -8,5 +8,6 @@ module.exports = {
     MovementModeStateAttribute: require("./MovementModeStateAttribute"),
     OperationModeStateAttribute: require("./OperationModeStateAttribute"),
     PersistentMapSettingStateAttribute: require("./PersistentMapSettingStateAttribute"),
+    RobotSpecificToggleStateAttribute: require("./RobotSpecificToggleStateAttribute"),
     StatusStateAttribute: require("./StatusStateAttribute")
 };


### PR DESCRIPTION
## Type of change

Type B:
- [x] New capability
- [ ] New core feature

RFC before I continue to add the rest of what's required.

Thinking about my comment about it on Telegram:

> I'm actually not sure though, because on the MQTT side it would be "nice to have" but it would be kind of hard to sync the topics since they wouldn't be part of the status

I eventually concluded that it's easier to just store it in the status. Front-ends may consider the status value good if it's present, but otherwise they should call the capability to update it (the `getToggle` and `setToggle` methods should update the status accordingly in implementations).

---

Motivations for having this capability:

- It works well for the LEDs toggle
- `set_repeat`:
  > The spinning side brush tends to launch tiny chunks where it's already been, so I usually have it repeat the cleaning to get those too.
  > Also sometimes I send it to mop the bathroom to dry water splashes, one pass usually isn't enough.
  > Right now with Valetudo I still do it, it's just more annoying since I have to wait for it to finish and start it again. Which is okay during lockdown, but in normal conditions I used to have it run while I'm out.

