### PR TITLE
Remove unnecessary availability_topic

### DIFF
--- a/lib/mqtt/homeassistant/components/HassComponent.js
+++ b/lib/mqtt/homeassistant/components/HassComponent.js
@@ -186,7 +186,6 @@ class HassComponent {
             payload_available: HomieCommonAttributes.STATE.READY,
             // MqttController will try to send "lost" at least once before cleanly disconnecting
             payload_not_available: HomieCommonAttributes.STATE.LOST,
-            availability_mode: "latest",
             device: this.hass.getAutoconfDeviceBoilerplate(),
         });
     }


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation

Since all it does is to set the "availability_mode" to 'latest', you can just scratch that, since it's the default anyway (https://github.com/home-assistant/core/blob/5ee373869a59266142001b62a5067d56c22bfddf/homeassistant/components/mqtt/mixins.py#L84).

Possibly fix #858