### PR TITLE
Publish state for both hass and homie, as the hass device availabilit…

### DIFF
--- a/lib/mqtt/MqttController.js
+++ b/lib/mqtt/MqttController.js
@@ -438,7 +438,7 @@ class MqttController {
      * @return {Promise<void>}
      */
     async setState(state) {
-        if (this.homieEnabled) {
+        if (this.homieEnabled || this.hassEnabled) {
             await this.asyncClient.publish(this.stateTopic, state, {
                 // @ts-ignore
                 qos: MqttCommonAttributes.QOS.AT_LEAST_ONCE,


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
# Description

Enable state topic when either hass or homie are enabled, because hass uses it as well

Fixes #857