### PR TITLE
fix(mqtt): Only migrate HAss topics if enabled

### DIFF
--- a/lib/mqtt/MqttController.js
+++ b/lib/mqtt/MqttController.js
@@ -302,7 +302,9 @@ class MqttController {
                     await HassAnchor.getTopicReference(HassAnchor.REFERENCE.AVAILABILITY).post(this.stateTopic);
 
                     // TODO: temporary, remove!
-                    await this.asyncClient.subscribe(this.getHassMigrationTopics());
+                    if (this.hassEnabled) {
+                        await this.asyncClient.subscribe(this.getHassMigrationTopics());
+                    }
 
                     await this.robotHandle.configure();
                     if (this.hassEnabled) {
@@ -319,11 +321,12 @@ class MqttController {
 
             this.client.on("message", (topic, message) => {
                 // TODO: temporary, remove!
-                if (topic.startsWith(this.hassController.autoconfPrefix + "/") && message.toString().length > 0) {
-                    this.migrateHass(topic).then();
-                    return;
+                if (this.hassEnabled) {
+                    if (topic.startsWith(this.hassController.autoconfPrefix + "/") && message.toString().length > 0) {
+                        this.migrateHass(topic).then();
+                        return;
+                    }
                 }
-
                 if (!Object.prototype.hasOwnProperty.call(this.subscriptions, topic)) {
                     return;
                 }


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation

Fixes crash when HAss is disabled. Issue due to the fact that the HAss topic migration is still attempted even with HAss disabled, and it still tries to access the `HassController`