### PR TITLE
Print error message when failing to load config file

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -31,7 +31,7 @@ class Configuration {
 
                 this.persist();
             } catch (e) {
-                Logger.error("Invalid configuration file!");
+                Logger.error("Invalid configuration file: ", e.message);
                 Logger.info("Writing new file using defaults");
 
                 try {


### PR DESCRIPTION
It is useful when trying to figure out a first config file for a dev setup, for example.