### PR TITLE
vendor(dreame.1C): Add/fix various Map & Volume capabilities

### DIFF
--- a/client/segment-edit-map.html
+++ b/client/segment-edit-map.html
@@ -10,16 +10,16 @@
     </div>
 
     <div class="map-page-buttons">
-        <ons-fab ripple id="segment-edit-add-split-line">
+        <ons-fab ripple id="segment-edit-add-split-line" class="hidden">
             <ons-icon icon="fa-arrows-h"></ons-icon>
         </ons-fab>
-        <ons-fab ripple id="segment-edit-split">
+        <ons-fab ripple id="segment-edit-split" class="hidden">
             <ons-icon icon="fa-cut"></ons-icon>
         </ons-fab>
-        <ons-fab ripple id="segment-edit-join">
+        <ons-fab ripple id="segment-edit-join" class="hidden">
             <ons-icon icon="fa-object-group"></ons-icon>
         </ons-fab>
-        <ons-fab ripple id="segment-rename">
+        <ons-fab ripple id="segment-rename" class="hidden">
             <ons-icon icon="fa-i-cursor"></ons-icon>
         </ons-fab>
     </div>
@@ -92,5 +92,10 @@
             grid-template-rows: auto;
             grid-gap: 0.5em;
         }
+
+        ons-fab.hidden {
+            display: none;
+        }
+
     </style>
 </ons-page>

--- a/client/segment-edit-map.js
+++ b/client/segment-edit-map.js
@@ -2,12 +2,31 @@
 import {VacuumMap} from "./js/js-modules/vacuum-map.js";
 import {ApiService} from "./services/api.service.js";
 
-function segmentConfigInit() {
+async function segmentConfigInit() {
     const map = new VacuumMap(document.getElementById("segment-edit-map"));
     const loadingBarSegmentEdit = document.getElementById("loading-bar-segment-edit");
-
+    const addSplitLineButton = document.getElementById("segment-edit-add-split-line");
+    const splitSegmentButton = document.getElementById("segment-edit-split");
+    const joinSegmentButton = document.getElementById("segment-edit-join");
+    const renameSegmentButton = document.getElementById("segment-rename");
     const topPage = fn.getTopPage();
     const mapData = JSON.parse(JSON.stringify(topPage.data.map)); //cloned for good measure
+
+    try {
+        let robotCapabilities = await ApiService.getRobotCapabilities();
+
+        if (robotCapabilities.includes("MapSegmentRenameCapability")) {
+            renameSegmentButton.classList.remove("hidden");
+        }
+
+        if (robotCapabilities.includes("MapSegmentEditCapability")) {
+            addSplitLineButton.classList.remove("hidden");
+            splitSegmentButton.classList.remove("hidden");
+            joinSegmentButton.classList.remove("hidden");
+        }
+    } catch (err) {
+        ons.notification.toast(err.message, {buttonLabel: "Dismiss", timeout: window.fn.toastErrorTimeout});
+    }
 
     mapData.layers.forEach(layer => {
         if (layer.type === "segment") {
@@ -20,7 +39,7 @@ function segmentConfigInit() {
 
     document.getElementById("segment-edit-map-page-h1").innerText = "Editing Segments";
 
-    document.getElementById("segment-edit-add-split-line").onclick = () => {
+    addSplitLineButton.onclick = () => {
         if (map.getLocations().virtualWalls.length === 0) {
             map.addVirtualWall(null, false, true);
         } else {
@@ -28,7 +47,7 @@ function segmentConfigInit() {
         }
     };
 
-    document.getElementById("segment-edit-split").onclick = async () => {
+    splitSegmentButton.onclick = async () => {
         let locations = map.getLocations();
 
         if (locations.selectedSegments.length === 1) {
@@ -64,7 +83,7 @@ function segmentConfigInit() {
         }
     };
 
-    document.getElementById("segment-edit-join").onclick = async () => {
+    joinSegmentButton.onclick = async () => {
         let locations = map.getLocations();
 
         if (locations.selectedSegments.length === 2) {
@@ -93,7 +112,7 @@ function segmentConfigInit() {
     const segmentRenameDialogNameInput = document.getElementById("segment-rename-input-name");
     let segmentId = null;
 
-    document.getElementById("segment-rename").onclick = () => {
+    renameSegmentButton.onclick = () => {
         let locations = map.getLocations();
         if (locations.selectedSegments.length === 1) {
             segmentId = locations.selectedSegments[0].id;

--- a/client/settings-persistent-data.js
+++ b/client/settings-persistent-data.js
@@ -29,9 +29,8 @@ async function updateSettingsPersistentDataPage() {
 
     try {
         let persistentMapEnabled = false;
-        const capabilites = await ApiService.getCapabilities();
+        const capabilities = await ApiService.getCapabilities();
         const state = await ApiService.getVacuumState();
-
         if (state) {
             const PersistentMapSettingStateAttribute = state.find(e => e.__class === "PersistentMapSettingStateAttribute");
 
@@ -40,7 +39,7 @@ async function updateSettingsPersistentDataPage() {
             }
         }
 
-        if (Array.isArray(capabilites) && capabilites.includes("PersistentMapControlCapability")) {
+        if (Array.isArray(capabilities) && capabilities.includes("PersistentMapControlCapability")) {
             document.getElementById("persistent_data_control_form").classList.remove("hidden");
 
             await initForm();
@@ -53,8 +52,7 @@ async function updateSettingsPersistentDataPage() {
                 document.getElementById("persistent_data_not_supported").classList.remove("hidden");
             }
         }
-
-        if (persistentMapEnabled === true && Array.isArray(capabilites) && capabilites.includes("MapResetCapability")) {
+        if (persistentMapEnabled === true && Array.isArray(capabilities) && capabilities.includes("MapResetCapability")) {
             document.getElementById("reset_map_row").classList.remove("hidden");
         }
     } catch (err) {

--- a/client/zones.js
+++ b/client/zones.js
@@ -220,7 +220,8 @@ async function ZonesInit() {
         if (robotCapabilities.includes("CombinedVirtualRestrictionsCapability")) {
             forbiddenZonesItem.hidden = false;
         }
-        if (robotCapabilities.includes("MapSegmentEditCapability")) {
+
+        if (robotCapabilities.includes("MapSegmentEditCapability") || robotCapabilities.includes("MapSegmentRenameCapability")) {
             segmentEditItem.hidden = false;
         }
 

--- a/lib/robots/dreame/Dreame1CValetudoRobot.js
+++ b/lib/robots/dreame/Dreame1CValetudoRobot.js
@@ -33,6 +33,9 @@ const MIOT_SERVICES = Object.freeze({
             WATER_TANK_ATTACHMENT: {
                 PIID: 9
             },
+            TASK_STATUS: {
+                PIID: 18 // if robot has a task: value = 0
+            },
             ADDITIONAL_CLEANUP_PROPERTIES: {
                 PIID: 21
             },
@@ -70,12 +73,18 @@ const MIOT_SERVICES = Object.freeze({
         ACTIONS: {
             LOCATE: {
                 AIID: 1
+            },
+            VOLUME_TEST: {
+                AIID: 3
             }
         }
     },
     VOICE: {
         SIID: 24,
         PROPERTIES: {
+            VOLUME: {
+                PIID: 1
+            },
             ACTIVE_VOICEPACK: {
                 PIID: 3
             },
@@ -349,6 +358,43 @@ class Dreame1CValetudoRobot extends DreameValetudoRobot {
             piid: MIOT_SERVICES.VACUUM_2.PROPERTIES.PERSISTENT_MAPS.PIID
         }));
 
+        this.registerCapability(new capabilities.DreameMapResetCapability({
+            robot: this,
+            miot_actions: {
+                map_edit: {
+                    siid: MIOT_SERVICES.MAP.SIID,
+                    aiid: MIOT_SERVICES.MAP.ACTIONS.EDIT.AIID
+                }
+            },
+            miot_properties: {
+                mapDetails: {
+                    piid: MIOT_SERVICES.MAP.PROPERTIES.MAP_DETAILS.PIID
+                },
+                actionResult: {
+                    piid: MIOT_SERVICES.MAP.PROPERTIES.ACTION_RESULT.PIID
+                }
+            }
+        }));
+
+        this.registerCapability(new capabilities.DreameMapSegmentEditCapability({
+            robot: this,
+            miot_actions: {
+                map_edit: {
+                    siid: MIOT_SERVICES.MAP.SIID,
+                    aiid: MIOT_SERVICES.MAP.ACTIONS.EDIT.AIID
+                }
+            },
+            miot_properties: {
+                mapDetails: {
+                    piid: MIOT_SERVICES.MAP.PROPERTIES.MAP_DETAILS.PIID
+                },
+                actionResult: {
+                    piid: MIOT_SERVICES.MAP.PROPERTIES.ACTION_RESULT.PIID
+                }
+            }
+        }));
+
+
         this.registerCapability(new capabilities.Dreame1CZoneCleaningCapability({
             robot: this,
             miot_actions: {
@@ -370,13 +416,14 @@ class Dreame1CValetudoRobot extends DreameValetudoRobot {
 
         this.registerCapability(new capabilities.DreameSpeakerVolumeControlCapability({
             robot: this,
-            siid: MIOT_SERVICES.AUDIO.SIID,
-            piid: MIOT_SERVICES.AUDIO.PROPERTIES.VOLUME.PIID
+            siid: MIOT_SERVICES.VOICE.SIID,
+            piid: MIOT_SERVICES.VOICE.PROPERTIES.VOLUME.PIID
         }));
+
         this.registerCapability(new capabilities.DreameSpeakerTestCapability({
             robot: this,
-            siid: MIOT_SERVICES.AUDIO.SIID,
-            aiid: MIOT_SERVICES.AUDIO.ACTIONS.VOLUME_TEST.AIID
+            siid: MIOT_SERVICES.LOCATE.SIID,
+            aiid: MIOT_SERVICES.LOCATE.ACTIONS.VOLUME_TEST.AIID
         }));
 
         this.registerCapability(new capabilities.Dreame1CVoicePackManagementCapability({
@@ -464,6 +511,10 @@ class Dreame1CValetudoRobot extends DreameValetudoRobot {
             },
             {
                 siid: MIOT_SERVICES.VACUUM_2.SIID,
+                piid: MIOT_SERVICES.VACUUM_2.PROPERTIES.TASK_STATUS.PIID
+            },
+            {
+                siid: MIOT_SERVICES.VACUUM_2.SIID,
                 piid: MIOT_SERVICES.VACUUM_2.PROPERTIES.FAN_SPEED.PIID
             },
             {
@@ -481,6 +532,10 @@ class Dreame1CValetudoRobot extends DreameValetudoRobot {
             {
                 siid: MIOT_SERVICES.BATTERY.SIID,
                 piid: MIOT_SERVICES.BATTERY.PROPERTIES.LEVEL.PIID
+            },
+            {
+                siid: MIOT_SERVICES.VACUUM_2.SIID,
+                piid: MIOT_SERVICES.VACUUM_2.PROPERTIES.PERSISTENT_MAPS.PIID
             }
         ].map(e => {
             e.did = this.deviceId; //TODO
@@ -514,6 +569,12 @@ class Dreame1CValetudoRobot extends DreameValetudoRobot {
                     switch (elem.piid) {
                         case MIOT_SERVICES.VACUUM_2.PROPERTIES.MODE.PIID: {
                             this.mode = elem.value;
+
+                            this.stateNeedsUpdate = true;
+                            break;
+                        }
+                        case MIOT_SERVICES.VACUUM_2.PROPERTIES.TASK_STATUS.PIID: {
+                            this.taskStatus = elem.value;
 
                             this.stateNeedsUpdate = true;
                             break;
@@ -552,6 +613,13 @@ class Dreame1CValetudoRobot extends DreameValetudoRobot {
                             this.state.upsertFirstMatchingAttribute(new entities.state.attributes.AttachmentStateAttribute({
                                 type: entities.state.attributes.AttachmentStateAttribute.TYPE.MOP,
                                 attached: elem.value === 1
+                            }));
+                            break;
+                        }
+                        case MIOT_SERVICES.VACUUM_2.PROPERTIES.PERSISTENT_MAPS.PIID: {
+                            this.state.upsertFirstMatchingAttribute(new entities.state.attributes.PersistentMapSettingStateAttribute({
+                                value: elem.value === 1 ? entities.state.attributes.PersistentMapSettingStateAttribute.VALUE.ENABLED :
+                                    entities.state.attributes.PersistentMapSettingStateAttribute.VALUE.DISABLED
                             }));
                             break;
                         }
@@ -594,6 +662,11 @@ class Dreame1CValetudoRobot extends DreameValetudoRobot {
             if (this.errorCode === "0" || this.errorCode === "" || this.errorCode === 0 || this.errorCode === undefined) {
                 statusValue = DreameValetudoRobot.STATUS_MAP[this.mode].value;
                 statusFlag = DreameValetudoRobot.STATUS_MAP[this.mode].flag;
+
+                if (statusValue === stateAttrs.StatusStateAttribute.VALUE.DOCKED && this.taskStatus === 0) {
+                    // Robot has a pending task but is charging due to low battery and will resume when battery >= 80%
+                    statusFlag = stateAttrs.StatusStateAttribute.FLAG.RESUMABLE;
+                }
             } else {
                 statusValue = stateAttrs.StatusStateAttribute.VALUE.ERROR;
 

--- a/lib/robots/dreame/Dreame1CValetudoRobot.js
+++ b/lib/robots/dreame/Dreame1CValetudoRobot.js
@@ -300,7 +300,7 @@ class Dreame1CValetudoRobot extends DreameValetudoRobot {
             }
         }));
 
-        this.registerCapability(new capabilities.DreameMapSegmentRenameCapability({ //TODO: verify
+        this.registerCapability(new capabilities.DreameMapSegmentRenameCapability({
             robot: this,
             miot_actions: {
                 map_edit: {
@@ -393,7 +393,6 @@ class Dreame1CValetudoRobot extends DreameValetudoRobot {
                 }
             }
         }));
-
 
         this.registerCapability(new capabilities.Dreame1CZoneCleaningCapability({
             robot: this,


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor/Code Cleanup
- [ ] Docs
- [x] Capability implementation for existing core capability
- [ ] New robot implementation
  
<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

Changes that apply to the Dreame 1C:
New Features:
- add mapResetCapability
- add persistentMapStateAttribute
- add "resumable" flag when robot is charging with a current task and will resume when 80% charged
- enable MapSegmentEditCapability

Fixes:
- fix "Save volume" - was calling wrong siid
- fix "Test volume" in sound settings - was calling wrong siid
- hide edit segment name if robot does not have `MapSegmentRenameCapability`
- hide create/split/join segment if robot does not have `MapSegmentEditCapability`

Refactor:
- `client/settings-persistent-data.js` : rename `capabilites` to `capabilities`


