### PR TITLE
feat(timers): add ValetudoGoToTimerAction

### DIFF
--- a/backend/lib/entities/core/ValetudoTimer.js
+++ b/backend/lib/entities/core/ValetudoTimer.js
@@ -17,6 +17,7 @@ class ValetudoTimer extends SerializableEntity {
      * @param {object} options.action.params
      * @param {string} [options.action.params.zone_id]
      * @param {Array<number>} [options.action.params.segment_ids]
+     * @param {string} [options.action.params.goto_id]
      * @param {number} [options.action.params.iterations]
      * @param {boolean} [options.action.params.custom_order]
      * @param {object} [options.metaData]
@@ -42,7 +43,8 @@ class ValetudoTimer extends SerializableEntity {
 ValetudoTimer.ACTION_TYPE = Object.freeze({
     FULL_CLEANUP: "full_cleanup",
     ZONE_CLEANUP: "zone_cleanup",
-    SEGMENT_CLEANUP: "segment_cleanup"
+    SEGMENT_CLEANUP: "segment_cleanup",
+    GOTO_LOCATION: "goto_location"
 });
 
 

--- a/backend/lib/scheduler/Scheduler.js
+++ b/backend/lib/scheduler/Scheduler.js
@@ -5,6 +5,7 @@ const ValetudoNTPClientSyncedState = require("../entities/core/ntpClient/Valetud
 const ValetudoSegmentCleanupTimerAction = require("./actions/ValetudoSegmentCleanupTimerAction");
 const ValetudoTimer = require("../entities/core/ValetudoTimer");
 const ValetudoZoneCleanupTimerAction = require("./actions/ValetudoZoneCleanupTimerAction");
+const ValetudoGoToTimerAction = require("./actions/ValetudoGoToTimerAction");
 
 class Scheduler {
     /**
@@ -82,6 +83,12 @@ class Scheduler {
                     segmentIds: timerDefinition.action?.params?.segment_ids,
                     iterations: timerDefinition.action?.params?.iterations,
                     customOrder: timerDefinition.action?.params?.custom_order
+                });
+                break;
+            case ValetudoTimer.ACTION_TYPE.GOTO_LOCATION:
+                action = new ValetudoGoToTimerAction({
+                    robot: this.robot,
+                    goToId: timerDefinition.action?.params?.goto_id
                 });
                 break;
         }

--- a/backend/lib/scheduler/actions/ValetudoGoToTimerAction.js
+++ b/backend/lib/scheduler/actions/ValetudoGoToTimerAction.js
@@ -1,0 +1,36 @@
+const ValetudoTimerAction = require("./ValetudoTimerAction");
+const GoToLocationCapability = require("../../core/capabilities/GoToLocationCapability");
+
+class ValetudoGoToTimerAction extends ValetudoTimerAction {
+    /**
+     * @param {object} options
+     * @param {import("../../core/ValetudoRobot")} options.robot
+     * @param {string} options.goToId
+     */
+    constructor(options) {
+        super(options);
+
+        this.goToId = options.goToId;
+    }
+
+    async run() {
+        if (!this.goToId) {
+            throw new Error("Missing goToId");
+        }
+
+        if (!this.robot.hasCapability(GoToLocationCapability.TYPE)) {
+            throw new Error("Robot is missing the GoToLocationCapability");
+        } else {
+            const capability = this.robot.capabilities[GoToLocationCapability.TYPE];
+            const goToLocationPreset = this.robot.config.get("goToLocationPresets")[this.goToId];
+
+            if (goToLocationPreset) {
+                return capability.goTo(goToLocationPreset);
+            } else {
+                throw new Error("There is no go to location preset with id " + this.goToId);
+            }
+        }
+    }
+}
+
+module.exports = ValetudoGoToTimerAction;


### PR DESCRIPTION
## Type of change

Type B:
- [X] New capability
- [ ] New core feature

# Description (Type B)

> My use-case and why I tried it out is sending it to the bin, as a reminder for myself. Now that I can let it run all by itself on a timer, I'm more forgetful about emptying it and cleaning the brushes. Granted it's a small use-case.

[Discussed on Telegram](https://t.me/c/1357472831/49545)
