### PR TITLE
Allow resetting the map when only the MapResetCapability is available

### DIFF
--- a/frontend/lib/settings-persistent-data.js
+++ b/frontend/lib/settings-persistent-data.js
@@ -52,7 +52,7 @@ async function updateSettingsPersistentDataPage() {
                 document.getElementById("persistent_data_not_supported").classList.remove("hidden");
             }
         }
-        if (persistentMapEnabled === true && Array.isArray(capabilities) && capabilities.includes("MapResetCapability")) {
+        if (Array.isArray(capabilities) && capabilities.includes("MapResetCapability")) {
             document.getElementById("reset_map_row").classList.remove("hidden");
         }
     } catch (err) {

--- a/frontend/lib/settings.js
+++ b/frontend/lib/settings.js
@@ -9,7 +9,8 @@ async function updateSettingsPage() {
             timers: robotCapabilities.includes("DoNotDisturbCapability"),
             "carpet-mode": robotCapabilities.includes("CarpetModeControlCapability"),
             "cleaning-history": false, // commented out in settings.html?
-            "persistent-data": robotCapabilities.includes("PersistentMapControlCapability"),
+            "persistent-data": robotCapabilities.includes("PersistentMapControlCapability") ||
+                robotCapabilities.includes("MapResetCapability"),
             consumables: robotCapabilities.includes("ConsumableMonitoringCapability"),
             wifi: robotCapabilities.includes("WifiConfigurationCapability"),
             mqtt: true,


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature

# Description (Type A)

The Dreame D9 has the `MapResetCapability`, but not the `PersistentMapControlCapability`. This fix allows resetting the map anyway by re-enabling that settings option in the persistent data configuration.

![image](https://user-images.githubusercontent.com/8963459/120096742-7ffe6680-c12d-11eb-91c3-baa8edb0d96f.png)

