### PR TITLE
 fix(vendor.viomi):Set correct env variables

### DIFF
--- a/deployment/viomi/etc/init.d/valetudo
+++ b/deployment/viomi/etc/init.d/valetudo
@@ -35,8 +35,7 @@ start_service() {
 	_fix_timezone
 
 	procd_open_instance
-	procd_set_param env VALETUDO_CONFIG_PATH=/mnt/UDISK/valetudo_config.json
-	procd_set_param env VALETUDO_SSH_AUTHORIZED_KEYS_LOCATION=/etc/dropbear/authorized_keys
+	procd_set_param env VALETUDO_CONFIG_PATH=/mnt/UDISK/valetudo_config.json VALETUDO_SSH_AUTHORIZED_KEYS_LOCATION=/etc/dropbear/authorized_keys
 	procd_set_param oom_adj $OOM_ADJ
 	procd_set_param command $PROG
 	procd_set_param stdout 1 # forward stdout of the command to logd


### PR DESCRIPTION


## Type of change

Type A:
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
 

<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

Fixed init script to take VALETUDO_CONFIG_PATH and  VALETUDO_SSH_AUTHORIZED_KEYS_LOCATION in the same statement.

 
<!-- Delete if there is none -->
Fixes #978 

