### PR TITLE
Prometheus exporter

### DIFF
--- a/backend/lib/webserver/PrometheusRouter.js
+++ b/backend/lib/webserver/PrometheusRouter.js
@@ -1,0 +1,81 @@
+const express = require("express");
+
+class PrometheusRouter {
+    /**
+     *
+     * @param {object} options
+     * @param {import("../core/ValetudoRobot")} options.robot
+     */
+    constructor(options) {
+        this.robot = options.robot;
+        this.router = express.Router({mergeParams: true});
+
+        this.initRoutes();
+    }
+
+    /**
+     * Create a name to be exposed for an Attribute.
+     *
+     * The name is a concatenation of the constant "valetudo", the optional
+     * type field and finally the Attribute's class name converted to snake
+     * case and without the "Attribute" suffix.
+     *
+     * @private
+     * @param {import("../entities/Attribute")} attr
+     * @return string
+     */
+    createName(attr) {
+        const prefix = "valetudo_";
+        const type = typeof attr?.type === "string" ? `${attr.type}_` : "";
+        const clss = attr.__class
+            .replace(/(Attribute)$/, "")
+            .replace(/(.+?)([A-Z])/g, "$1_$2");
+
+        return (prefix + type + clss).toLowerCase();
+    }
+
+    /**
+     * Create a numeric value to be exposed for an Attribute.
+     *
+     * @private
+     * @param {import("../entities/Attribute")} attr
+     * @return number
+     */
+    createValue(attr) {
+        const fields = ["attached", "flag", "level", "remaining", "value"];
+        for (const field of fields) {
+            if (!attr.hasOwnProperty(field)) {
+                continue;
+            }
+
+            const numProperty = Number(attr[field]);
+            if (isNaN(numProperty)) {
+                continue;
+            }
+
+            return numProperty;
+        }
+        return NaN;
+    }
+
+    initRoutes() {
+        this.router.get("/", async (req, res) => {
+            const polledState = await this.robot.pollState();
+
+            const metrics = polledState.attributes
+                .map(attr => [this.createName(attr), this.createValue(attr)])
+                .filter(tpl => !isNaN(tpl[1]))
+                .map(tpl => `# TYPE ${tpl[0]} gauge\n${tpl[0]} ${tpl[1]}`)
+                .join("\n");
+
+            res.set("Content-Type", "text/plain; version=0.0.4");
+            res.send(metrics);
+        });
+    }
+
+    getRouter() {
+        return this.router;
+    }
+}
+
+module.exports = PrometheusRouter;

--- a/backend/lib/webserver/WebServer.js
+++ b/backend/lib/webserver/WebServer.js
@@ -20,6 +20,7 @@ const ValetudoRouter = require("./ValetudoRouter");
 const fs = require("fs");
 const MiioValetudoRobot = require("../robots/MiioValetudoRobot");
 const NTPClientRouter = require("./NTPClientRouter");
+const PrometheusRouter = require("./PrometheusRouter");
 const SystemRouter = require("./SystemRouter");
 const TimerRouter = require("./TimerRouter");
 
@@ -109,6 +110,8 @@ class WebServer {
         this.app.use("/api/v2/timers/", new TimerRouter({config: this.config, robot: this.robot, validator: this.validator}).getRouter());
 
         this.app.use("/api/v2/system/", new SystemRouter({}).getRouter());
+
+        this.app.use("/metrics", new PrometheusRouter({robot: this.robot}).getRouter());
 
         // TODO: This should point at a build
         this.app.use(express.static(path.join(__dirname, "../../..", "frontend/lib")));


### PR DESCRIPTION
## Type of change
This pull requests introduces an experimental Prometheus exporter to Valetudo.
Therefore already existing data will be served within Prometheus' format under the typical `/metrics` endpoint.

I'm not quite sure if this really meets this project's scope, but I personally wanted this feature for my "monitoring" and I had fun building it. Thus, I am open for discussion about its usefulness.

I tested the code both on the `MockRobot` as well as the real Roborock S5.

The Prometheus output after a short test drive looks like the following:
```
# TYPE valetudo_dustbin_attachment_state gauge
valetudo_dustbin_attachment_state 1
# TYPE valetudo_watertank_attachment_state gauge
valetudo_watertank_attachment_state 0
# TYPE valetudo_mop_attachment_state gauge
valetudo_mop_attachment_state 0
# TYPE valetudo_battery_state gauge
valetudo_battery_state 97
# TYPE valetudo_area_latest_cleanup_statistics gauge
valetudo_area_latest_cleanup_statistics 88650
# TYPE valetudo_duration_latest_cleanup_statistics gauge
valetudo_duration_latest_cleanup_statistics 734
```

On a hackish Grafana Dashboard, it looks like the following:
![valetudo-grafana](https://user-images.githubusercontent.com/8402811/125353467-e4365c00-e362-11eb-92ca-632ddf43c973.jpg)

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature

It should be _Type B_, but I'm not sure what to tick.

# Description (Type B)
> While of course appreciated, please don't open PRs with features without discussing them first.
> _Especially_ if it's a new capability.

Of course, I only read this one after opening a PR. Sorry, my bad.
Thus, there is currently no such discussion. I will open this PR and create a related issue (update: now linked).

Feature discussion thread: #984
