### PR TITLE
feat: Allow reuse of the bundled nodejs runtime binary

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,37 +1,98 @@
 #!/usr/bin/env node
-const Logger = require("./lib/Logger");
-const process = require("process");
-const Valetudo = require("./lib/Valetudo");
 
-var valetudo = new Valetudo();
+/**
+ * This enables the use of the nodejs runtime packaged with the valetudo binary for other small
+ * js applications on the robot.
+ *
+ * If we detect that
+ *      a) We're packaged
+ *      b1) There's a .js file as the first argument
+ *          OR
+ *      b2) --repl is provided
+ *
+ * we undo all pkg patching and then
+ *      b1) just eval whatever there is.
+ *          OR
+ *      b2) enter REPL
+ */
+if (
+    !(
+        (typeof process.argv[1] === "string" && process.argv[1].toLowerCase().includes("snapshot")) &&
+        (
+            (typeof process.argv[2] === "string" && process.argv[2].toLowerCase().endsWith(".js")) ||
+            (process.argv[2] === "--repl")
+        )
 
-process.on("unhandledRejection", error => {
-    Logger.error("unhandledRejection", error);
-});
+    )
+) {
+    const Logger = require("./lib/Logger");
+    const process = require("process");
+    const Valetudo = require("./lib/Valetudo");
 
-async function shutdown() {
-    try {
-        await valetudo.shutdown();
-        // need to exit here because otherwise the process would stay open
-        process.exit(0);
-    } catch (err) {
-        Logger.error("Error occured: ", err.name, " - ", err.message);
-        Logger.error(err.stack);
-        process.exit(1);
+    var valetudo = new Valetudo();
+
+    process.on("unhandledRejection", error => {
+        Logger.error("unhandledRejection", error);
+    });
+
+    // eslint-disable-next-line no-inner-declarations
+    async function shutdown() {
+        try {
+            await valetudo.shutdown();
+            // need to exit here because otherwise the process would stay open
+            process.exit(0);
+        } catch (err) {
+            Logger.error("Error occured: ", err.name, " - ", err.message);
+            Logger.error(err.stack);
+            process.exit(1);
+        }
     }
+
+    // Signal termination handler - used if the process is killed
+    // (e.g. kill command, service valetudo stop, reboot (via upstart),...)
+    process.on("SIGTERM", shutdown);
+
+    // Signal interrupt handler -
+    // e.g. if the process is aborted by Ctrl + C (during dev)
+    process.on("SIGINT", shutdown);
+
+    process.on("exit", function (code) {
+        Logger.info("exiting with code " + code + "...");
+        if (code !== 0) {
+            Logger.error("Stacktrace that lead to the process exiting:", new Error().stack);
+        }
+    });
+} else {
+    if ((process.argv[2] === "--repl")) {
+        const repl = require("repl");
+
+        repl.start({
+            useGlobal: true
+        });
+    } else {
+        const fs = require("fs");
+        const module = require("module");
+
+        let script;
+
+        try {
+            script = fs.readFileSync(process.argv[2]);
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error("Failed to load " + process.argv[2] + " for execution.", e);
+            process.exit(-1);
+        }
+
+        // undo pkgs require patching
+        // eslint-disable-next-line no-global-assign
+        require = module.prototype.require;
+
+
+        eval(script.toString());
+    }
+
 }
 
-// Signal termination handler - used if the process is killed
-// (e.g. kill command, service valetudo stop, reboot (via upstart),...)
-process.on("SIGTERM", shutdown);
 
-// Signal interrupt handler -
-// e.g. if the process is aborted by Ctrl + C (during dev)
-process.on("SIGINT", shutdown);
 
-process.on("exit", function(code) {
-    Logger.info("exiting with code " + code + "...");
-    if (code !== 0) {
-        Logger.error("Stacktrace that lead to the process exiting:", new Error().stack);
-    }
-});
+


### PR DESCRIPTION
This is an idea I had where I'm not 100% sure if it really is a good one.

Valetudo uses vercel/pkg to take the Valetudo JS Code and simply glue it onto a statically compiled nodejs runtime binary.
This enables us to install/upgrade Valetudo by copying a single binary which is neat.

What is not neat however is that everything bundled with vercel/pkg will be at least 25MB in size as they all have their own bundled nodejs runtime.
As space is quite limited on the robots, this PR would allow using the nodejs runtime bundled with Valetudo to execute arbitrary other js code. For example, it could be used to add a Telegram Bot Microservice which also runs on the Robot without requiring another 25MB nodejs binary.

The PR adds code that runs before every line of Valetudo code which checks for a ".js" file in the process.argv.
If one is found, it is thrown into `eval()`.
It is also possible to use `--repl` as the first parameter to enter the nodejs REPL interactive shell for quick testing.

The runtime would still use the baked-in v8 options such as the heap size so it's not a direct replacement for a nodejs binary.
Though, I'd assume that it should work well enough for most cases


As Valetudo only uses environment variables and its config file for configuration, there also shouldn't be any collisions by using process.argv

This may or may not be a terrible idea.
Therefore, feedback much appreciated