### PR TITLE
Add error code 11 for Dreame robots

### DIFF
--- a/backend/lib/robots/dreame/capabilities/DreameCombinedVirtualRestrictionsCapability.js
+++ b/backend/lib/robots/dreame/capabilities/DreameCombinedVirtualRestrictionsCapability.js
@@ -129,6 +129,8 @@ class DreameCombinedVirtualRestrictionsCapability extends CombinedVirtualRestric
                     return;
                 case 10:
                     throw new Error("Cannot save temporary virtual restrictions. A persistent map exists.");
+                case 11:
+                    throw new Error("Cannot save virtual restrictions. No persistent map exists. Let the robot do a full clean before saving restrictions.");
                 default:
                     throw new Error("Got error " + res.out[0].value + " while saving virtual restrictions.");
             }


### PR DESCRIPTION
## Type of change

Type A:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

The L10 Pro wouldn't save forbidden zones until I let it return itself to the dock after asking it to do a clean.
All I would get is "error code 11" under the catch all of this switch statement.
 
Feature discussion thread: See Telegram
