### PR TITLE
Add error code 64 for Dreame robots

### DIFF
--- a/backend/lib/robots/dreame/DreameValetudoRobot.js
+++ b/backend/lib/robots/dreame/DreameValetudoRobot.js
@@ -329,6 +329,7 @@ DreameValetudoRobot.ERROR_CODES = {
     "49": "LDS bumper jammed",
     "51": "Filter jammed",
     "54": "Wall sensor dirty",
+    "64": "Robot trapped from dock by forbidden zones",
     "-2": "Stuck inside restricted area"
 };
 


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

This error code happens when you trap the robot away from its dock with forbidden zones
