### PR TITLE
docs: Suggest install of hass Lovelace card

### DIFF
--- a/docs/_pages/integrations/home-assistant-integration.md
+++ b/docs/_pages/integrations/home-assistant-integration.md
@@ -66,7 +66,7 @@ data:
 For more features check out the [MQTT documentation](/pages/integrations/mqtt.html).
 
 
-### PNG map generation
+### Map display
 
-If you are on Hass.io and want the map also on your dashboards of Home Assistant, use the [Lovelace Valetudo Map Card
+If you are on Hass.io and want the map also on your dashboards of Home Assistant, you can use the [Lovelace Valetudo Map Card
 ](https://github.com/TheLastProject/lovelace-valetudo-map-card).

--- a/docs/_pages/integrations/home-assistant-integration.md
+++ b/docs/_pages/integrations/home-assistant-integration.md
@@ -68,4 +68,5 @@ For more features check out the [MQTT documentation](/pages/integrations/mqtt.ht
 
 ### PNG map generation
 
-If you on Hass.io and want the map also on your dashboards of Home Assistant, use the [ICantBelieveItsNotValetudo-Addon](https://github.com/Poeschl/Hassio-Addons/tree/master/ICantBelieveItsNotValetudo).
+If you are on Hass.io and want the map also on your dashboards of Home Assistant, use the [Lovelace Valetudo Map Card
+](https://github.com/TheLastProject/lovelace-valetudo-map-card).


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor/Code Cleanup
- [x] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature

The [Lovelace Valetudo Map Card](https://github.com/TheLastProject/lovelace-valetudo-map-card) works natively without any middleware like "I can't believe it's not Valetudo", so this PR points the docs on adding Valetudo's map to hass to the Lovelace card instead.