### PR TITLE
Timer UI

### DIFF
--- a/backend/lib/robots/mock/capabilities/MockMapSegmentationCapability.js
+++ b/backend/lib/robots/mock/capabilities/MockMapSegmentationCapability.js
@@ -12,8 +12,21 @@ class MockMapSegmentationCapability extends MapSegmentationCapability {
         return [
             new ValetudoMapSegment({ id: "foo_id", name: "Foo"}),
             new ValetudoMapSegment({ id: "bar_id", name: "Bar"}),
-            new ValetudoMapSegment({ id: "unnamed_id" })
+            new ValetudoMapSegment({ id: "b774401e-4227-43bb-8fde-c166cfa7a028" })
         ];
+    }
+
+    /**
+     * @returns {import("../../../core/capabilities/MapSegmentationCapability").MapSegmentationCapabilityProperties}
+     */
+    getProperties() {
+        return {
+            iterationCount: {
+                min: 1,
+                max: 2
+            },
+            customOrderSupport: true
+        };
     }
 
     /**

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "@material-ui/lab": "5.0.0-alpha.40",
     "axios": "0.21.1",
     "color": "3.1.4",
+    "date-fns": "2.23.0",
     "konva": "8.1.1",
     "notistack": "1.0.6",
     "react": "17.0.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import {createTheme, CssBaseline, ThemeProvider, /*useMediaQuery,*/} from '@material-ui/core';
+import {createTheme, CssBaseline, ThemeProvider,} from '@material-ui/core';
+import AdapterDateFns from '@material-ui/lab/AdapterDateFns';
+import LocalizationProvider from '@material-ui/lab/LocalizationProvider';
 import AppRouter from './AppRouter';
 import CapabilitiesProvider from './CapabilitiesProvider';
 import {SnackbarProvider} from 'notistack';
@@ -12,8 +14,8 @@ const App = (): JSX.Element => {
     //const prefersDarkMode = useMediaQuery('(prefers-color-scheme: dark)');
 
     const theme = React.useMemo(
-        () =>
-            {return createTheme({
+        () => {
+            return createTheme({
                 palette: {
                     mode: /*prefersDarkMode ? */ 'dark' /*: 'light' */,
                 },
@@ -26,23 +28,26 @@ const App = (): JSX.Element => {
                     noMop: {stroke: '#CC00FF', fill: '#58006E66'},
                     active: {stroke: '#35911A', fill: '#6AF5424C'},
                 },
-            })},
+            })
+        },
         [/*prefersDarkMode*/]
     );
 
     return (
         <QueryClientProvider client={queryClient}>
-            <ThemeProvider theme={theme}>
-                <CssBaseline/>
+            <LocalizationProvider dateAdapter={AdapterDateFns}>
+                <ThemeProvider theme={theme}>
+                    <CssBaseline/>
 
-                <SnackbarProvider maxSnack={3} autoHideDuration={5000}>
-                    <CapabilitiesProvider>
-                        <AppRouter/>
-                    </CapabilitiesProvider>
-                </SnackbarProvider>
-            </ThemeProvider>
+                    <SnackbarProvider maxSnack={3} autoHideDuration={5000}>
+                        <CapabilitiesProvider>
+                            <AppRouter/>
+                        </CapabilitiesProvider>
+                    </SnackbarProvider>
+                </ThemeProvider>
 
-            <ReactQueryDevtools initialIsOpen={false}/>
+                <ReactQueryDevtools initialIsOpen={false}/>
+            </LocalizationProvider>
         </QueryClientProvider>
     );
 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -62,7 +62,7 @@ export interface MapSegmentationProperties {
         min: number;
         max: number;
     };
-    customOrderSupport: boolean
+    customOrderSupport: boolean;
 }
 
 export interface GoToLocation {
@@ -122,7 +122,27 @@ export interface SystemHostInfo {
 }
 
 export interface MapSegmentationActionRequestParameters {
-    segment_ids: string[],
-    iterations?: number,
-    customOrder?: boolean
+    segment_ids: string[];
+    iterations?: number;
+    customOrder?: boolean;
+}
+
+export interface Timer {
+    id: string;
+    enabled: boolean;
+    dow: Array<number>;
+    hour: number;
+    minute: number;
+    action: {
+        type: string;
+        params: Record<string, unknown>;
+    };
+}
+
+export interface TimerInformation {
+    [id: string]: Timer;
+}
+
+export interface TimerProperties {
+    supportedActions: Array<string>;
 }

--- a/frontend/src/settings/SettingsRouter.tsx
+++ b/frontend/src/settings/SettingsRouter.tsx
@@ -1,6 +1,7 @@
 import {Route, Switch} from 'react-router';
 import {useRouteMatch} from 'react-router-dom';
 import About from './About';
+import Timers from "./timers";
 
 const SettingsRouter = (): JSX.Element => {
     const {path} = useRouteMatch();
@@ -9,6 +10,9 @@ const SettingsRouter = (): JSX.Element => {
         <Switch>
             <Route exact path={path + "/about"}>
                 <About/>
+            </Route>
+            <Route exact path={path + "/timers"}>
+                <Timers/>
             </Route>
             <Route path="*">
                 <h3>Unknown route</h3>

--- a/frontend/src/settings/timers/ActionControls.tsx
+++ b/frontend/src/settings/timers/ActionControls.tsx
@@ -1,0 +1,381 @@
+import React, { FunctionComponent } from "react";
+import { TimerActionControlProps } from "./types";
+import {
+    Capability,
+    useGoToLocationPresetsQuery,
+    useMapSegmentationPropertiesQuery,
+    useSegmentsQuery,
+    useZonePresetsQuery,
+} from "../../api";
+import {
+    Box,
+    Checkbox,
+    CircularProgress,
+    FormControl,
+    FormControlLabel,
+    IconButton,
+    InputLabel,
+    List,
+    ListItem,
+    ListItemText,
+    ListSubheader,
+    MenuItem,
+    Select,
+    Typography,
+} from "@material-ui/core";
+import { Add as AddIcon, Remove as RemoveIcon } from "@material-ui/icons";
+
+import { deepCopy } from "../../utils";
+
+export const validateParams: Record<
+    string,
+    (props: Record<string, any>) => boolean
+> = {
+    full_cleanup: () => {
+        return true;
+    },
+    zone_cleanup: (props) => {
+        return props.zone_id && props.zone_id !== "none";
+    },
+    segment_cleanup: (props) => {
+        return props.segment_ids?.length > 0 && (props.iterations ?? 1 > 0);
+    },
+    goto_location: (props) => {
+        return props.goto_id && props.goto_id !== "none";
+    },
+};
+
+export const FullCleanupControls: FunctionComponent<TimerActionControlProps> =
+    () => {
+        // No params for full_cleanup
+        return null;
+    };
+
+export const ZoneCleanupControls: FunctionComponent<TimerActionControlProps> =
+    ({ disabled, params, setParams }) => {
+        const selectedZoneId = params.zone_id ?? "none";
+
+        const {
+            data: zonePresets,
+            isLoading: zonePresetsLoading,
+            isError: zonePresetsError,
+        } = useZonePresetsQuery();
+
+        const zoneMenuItems = React.useMemo(() => {
+            if (!zonePresets) {
+                return null;
+            }
+            return zonePresets.map(({ name, id }) => {
+                return (
+                    <MenuItem key={id} value={id}>
+                        {name || "Unnamed zone: " + id}
+                    </MenuItem>
+                );
+            });
+        }, [zonePresets]);
+
+        if (zonePresetsLoading) {
+            return <CircularProgress />;
+        }
+
+        if (zonePresetsError) {
+            return (
+                <Typography color="error">
+                    Error loading {Capability.ZoneCleaning}
+                </Typography>
+            );
+        }
+
+        return (
+            <FormControl>
+                <InputLabel id={"zone-label"}>Select zone</InputLabel>
+                <Select
+                    labelId={"zone-label"}
+                    id={"zone-select"}
+                    value={selectedZoneId}
+                    label="Select zone"
+                    disabled={disabled}
+                    onChange={(e) => {
+                        setParams({
+                            zone_id: e.target.value,
+                        });
+                    }}
+                >
+                    <MenuItem value={"none"}>
+                        <em>No zone selected</em>
+                    </MenuItem>
+                    {zoneMenuItems}
+                </Select>
+            </FormControl>
+        );
+    };
+
+export const SegmentCleanupControls: FunctionComponent<TimerActionControlProps> =
+    ({ disabled, params, setParams }) => {
+        const segmentIds: Array<string> = React.useMemo(() => {
+            return (params.segment_ids as Array<string>) || [];
+        }, [params]);
+        const iterationCount: number = (params.iterations as number) || 1;
+        const customOrder: boolean = (params.custom_order as boolean) ?? false;
+
+        const {
+            data: segmentationProps,
+            isLoading: segmentationPropsLoading,
+            isError: segmentationPropsError,
+        } = useMapSegmentationPropertiesQuery();
+        const {
+            data: segments,
+            isLoading: segmentsLoading,
+            isError: segmentsLoadError,
+        } = useSegmentsQuery();
+
+        const getSegmentLabel = React.useCallback(
+            (segmentId: string) => {
+                if (!segments) {
+                    return "";
+                }
+                return (
+                    segments.find((s) => {
+                        return s.id === segmentId;
+                    })?.name || "Unnamed segment: " + segmentId
+                );
+            },
+            [segments]
+        );
+
+        const selectedSegmentList = React.useMemo(() => {
+            return segmentIds.map((segmentId) => {
+                return (
+                    <ListItem
+                        key={segmentId}
+                        secondaryAction={
+                            <IconButton
+                                disabled={disabled}
+                                edge="end"
+                                aria-label="remove"
+                                onClick={() => {
+                                    const newParams = deepCopy(params);
+                                    const sids: Array<string> =
+                                        newParams.segment_ids as Array<string>;
+                                    const removeIdx = sids.indexOf(segmentId);
+                                    if (removeIdx !== -1) {
+                                        sids.splice(removeIdx, 1);
+                                    }
+                                    setParams(newParams);
+                                }}
+                            >
+                                <RemoveIcon />
+                            </IconButton>
+                        }
+                    >
+                        <ListItemText primary={getSegmentLabel(segmentId)} />
+                    </ListItem>
+                );
+            });
+        }, [getSegmentLabel, params, setParams, disabled, segmentIds]);
+
+        const availableSegmentList = React.useMemo(() => {
+            if (!segments) {
+                return null;
+            }
+            return segments
+                .filter((s) => {
+                    return segmentIds.indexOf(s.id) === -1;
+                })
+                .map((segment) => {
+                    return (
+                        <ListItem
+                            key={segment.id}
+                            secondaryAction={
+                                <IconButton
+                                    disabled={disabled}
+                                    edge="end"
+                                    aria-label="add"
+                                    onClick={() => {
+                                        const newParams = deepCopy(params);
+                                        if (newParams.segment_ids) {
+                                            const sids: Array<string> =
+                                                newParams.segment_ids as Array<string>;
+                                            sids.push(segment.id);
+                                        } else {
+                                            newParams.segment_ids = [
+                                                segment.id,
+                                            ];
+                                        }
+                                        setParams(newParams);
+                                    }}
+                                >
+                                    <AddIcon />
+                                </IconButton>
+                            }
+                        >
+                            <ListItemText
+                                primary={
+                                    segment.name ||
+                                    "Unnamed segment: " + segment.id
+                                }
+                            />
+                        </ListItem>
+                    );
+                });
+        }, [disabled, params, segmentIds, setParams, segments]);
+
+        if (segmentationPropsLoading || segmentsLoading) {
+            return <CircularProgress />;
+        }
+
+        if (
+            segmentationPropsError ||
+            segmentsLoadError ||
+            !segmentationProps ||
+            !segments
+        ) {
+            return (
+                <Typography color="error">
+                    Error loading {Capability.MapSegmentation}
+                </Typography>
+            );
+        }
+
+        const iterationItems = [];
+        for (
+            let i = segmentationProps.iterationCount.min;
+            i <= segmentationProps.iterationCount.max;
+            i++
+        ) {
+            iterationItems.push(
+                <MenuItem key={i} value={i}>
+                    {i} {i === 1 ? "Iteration" : "Iterations"}
+                </MenuItem>
+            );
+        }
+
+        // Since material-ui does not support reordering lists yet, we implement our custom sorting
+        // See https://next.material-ui.com/getting-started/supported-components/#main-content
+
+        return (
+            <>
+                <FormControl>
+                    <InputLabel id="segment-iterations-label">
+                        Iterations
+                    </InputLabel>
+                    <Select
+                        labelId="segment-iterations-label"
+                        id="segment-iterations-select"
+                        value={iterationCount}
+                        disabled={disabled}
+                        label="Iterations"
+                        onChange={(e) => {
+                            const newParams = deepCopy(params);
+                            newParams.iterations = e.target.value;
+                            setParams(newParams);
+                        }}
+                    >
+                        {iterationItems}
+                    </Select>
+                </FormControl>
+                <Box pt={1} />
+
+                {segmentationProps.customOrderSupport && (
+                    <FormControlLabel
+                        control={
+                            <Checkbox
+                                disabled={disabled}
+                                checked={customOrder}
+                                onChange={(e) => {
+                                    const newParams = deepCopy(params);
+                                    newParams.custom_order = e.target.checked;
+                                    setParams(newParams);
+                                }}
+                            />
+                        }
+                        label="Use custom order"
+                    />
+                )}
+                <Box pt={1} />
+
+                <List
+                    dense
+                    subheader={
+                        <ListSubheader component="div">
+                            Available segments
+                        </ListSubheader>
+                    }
+                >
+                    {availableSegmentList}
+                </List>
+
+                <List
+                    dense
+                    subheader={
+                        <ListSubheader component="div">
+                            Selected segments
+                        </ListSubheader>
+                    }
+                >
+                    {selectedSegmentList}
+                </List>
+            </>
+        );
+    };
+
+export const GoToLocationControls: FunctionComponent<TimerActionControlProps> =
+    ({ params, setParams, disabled }) => {
+        const selectedGoToId = params.goto_id ?? "none";
+
+        const {
+            data: goToLocations,
+            isLoading: goToLocationPresetsLoading,
+            isError: goToLocationPresetLoadError,
+        } = useGoToLocationPresetsQuery();
+
+        const goToMenuItems = React.useMemo(() => {
+            if (!goToLocations) {
+                return null;
+            }
+            return goToLocations.map(({ name, id }) => {
+                return (
+                    <MenuItem key={id} value={id}>
+                        {name || "Unnamed go to location: " + id}
+                    </MenuItem>
+                );
+            });
+        }, [goToLocations]);
+
+        if (goToLocationPresetsLoading) {
+            return <CircularProgress />;
+        }
+
+        if (goToLocationPresetLoadError) {
+            return (
+                <Typography color="error">
+                    Error loading {Capability.GoToLocation}
+                </Typography>
+            );
+        }
+
+        return (
+            <FormControl>
+                <InputLabel id={"go-to-location-label"}>
+                    Select go to location
+                </InputLabel>
+                <Select
+                    labelId={"go-to-location-label"}
+                    id={"go-to-location-select"}
+                    value={selectedGoToId}
+                    label="Select go to location"
+                    disabled={disabled}
+                    onChange={(e) => {
+                        setParams({
+                            goto_id: e.target.value,
+                        });
+                    }}
+                >
+                    <MenuItem value={"none"}>
+                        <em>No go to location selected</em>
+                    </MenuItem>
+                    {goToMenuItems}
+                </Select>
+            </FormControl>
+        );
+    };

--- a/frontend/src/settings/timers/TimerCard.tsx
+++ b/frontend/src/settings/timers/TimerCard.tsx
@@ -1,0 +1,215 @@
+import {
+    Box,
+    Button,
+    Card,
+    CardContent,
+    Checkbox,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogContentText,
+    DialogTitle,
+    Divider,
+    FormControlLabel,
+    Grid,
+    IconButton,
+    Typography,
+} from "@material-ui/core";
+import { Delete as DeleteIcon, Edit as EditIcon } from "@material-ui/icons";
+import React, { FunctionComponent } from "react";
+import { Timer, TimerProperties } from "../../api";
+import TimerEditDialog from "./TimerEditDialog";
+
+export const weekdays = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+];
+
+type TimerCardProps = {
+    timer: Timer;
+    timerProperties: TimerProperties;
+    onSave: (newProps: Timer) => void;
+    onDelete: () => void;
+};
+
+export const timerActionLabels: Record<string, string> = {
+    full_cleanup: "Full cleanup",
+    zone_cleanup: "Zone cleanup",
+    segment_cleanup: "Segment cleanup",
+    goto_location: "Go to location",
+};
+
+const TimerCard: FunctionComponent<TimerCardProps> = ({
+    timer,
+    timerProperties,
+    onSave,
+    onDelete,
+}): JSX.Element => {
+    const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
+    const [editDialogOpen, setEditDialogOpen] = React.useState(false);
+
+    const weekdayLabels = React.useMemo(() => {
+        return weekdays.map((day, i) => {
+            const enabled = timer.dow.includes(i);
+
+            return (
+                <Typography
+                    key={day}
+                    variant={"body2"}
+                    color={enabled ? "textPrimary" : "textSecondary"}
+                    component={"span"}
+                    sx={i < weekdays.length - 1 ? { marginRight: 1 } : {}}
+                >
+                    {day.toUpperCase().slice(0, 3)}
+                </Typography>
+            );
+        });
+    }, [timer]);
+
+    const timeLabel = React.useMemo(() => {
+        // Year 0 breaks everything
+        const date = new Date(
+            Date.UTC(2020, 0, 0, timer.hour, timer.minute, 0, 0)
+        );
+        return (
+            <>
+                <Typography
+                    variant={"h4"}
+                    component={"span"}
+                    sx={{ marginRight: 2 }}
+                >
+                    {String(date.getHours()).padStart(2, "0")}:
+                    {String(date.getMinutes()).padStart(2, "0")}
+                </Typography>
+                <Typography
+                    variant={"h5"}
+                    component={"span"}
+                    color={"textSecondary"}
+                >
+                    {String(date.getUTCHours()).padStart(2, "0")}:
+                    {String(date.getUTCMinutes()).padStart(2, "0")} UTC
+                </Typography>
+            </>
+        );
+    }, [timer]);
+
+    const actionLabel = React.useMemo(() => {
+        const label = timerActionLabels[timer.action.type];
+
+        return <Typography variant={"subtitle1"}>{label}</Typography>;
+    }, [timer]);
+
+    return (
+        <Card key={timer.id}>
+            <CardContent>
+                <Grid
+                    container
+                    spacing={4}
+                    alignItems="center"
+                    justifyContent="space-between"
+                >
+                    <Grid item>
+                        <FormControlLabel
+                            control={
+                                <Checkbox
+                                    checked={timer.enabled}
+                                    disabled={true}
+                                />
+                            }
+                            disableTypography
+                            label={
+                                <Typography
+                                    variant="h6"
+                                    gutterBottom
+                                    sx={{ marginBottom: 0 }}
+                                    title={timer.id}
+                                >
+                                    Timer
+                                </Typography>
+                            }
+                        />
+                    </Grid>
+                    <Grid item>
+                        <IconButton
+                            onClick={() => {
+                                setDeleteDialogOpen(true);
+                            }}
+                            color="error"
+                        >
+                            <DeleteIcon />
+                        </IconButton>
+                        <IconButton
+                            onClick={() => {
+                                setEditDialogOpen(true);
+                            }}
+                            color="warning"
+                        >
+                            <EditIcon />
+                        </IconButton>
+                    </Grid>
+                </Grid>
+
+                <Divider />
+                {weekdayLabels}
+
+                <Box pt={1} />
+
+                {timeLabel}
+
+                {actionLabel}
+
+                <Dialog
+                    open={deleteDialogOpen}
+                    onClose={() => {
+                        setDeleteDialogOpen(false);
+                    }}
+                >
+                    <DialogTitle>Delete timer?</DialogTitle>
+                    <DialogContent>
+                        <DialogContentText>
+                            Do you really want to delete this timer?
+                        </DialogContentText>
+                    </DialogContent>
+                    <DialogActions>
+                        <Button
+                            onClick={() => {
+                                setDeleteDialogOpen(false);
+                            }}
+                        >
+                            No
+                        </Button>
+                        <Button
+                            onClick={() => {
+                                setDeleteDialogOpen(false);
+                                onDelete();
+                            }}
+                            autoFocus
+                        >
+                            Yes
+                        </Button>
+                    </DialogActions>
+                </Dialog>
+
+                <TimerEditDialog
+                    timer={timer}
+                    open={editDialogOpen}
+                    onCancel={() => {
+                        setEditDialogOpen(false);
+                    }}
+                    onSave={(timer) => {
+                        setEditDialogOpen(false);
+                        onSave(timer);
+                    }}
+                    timerProperties={timerProperties}
+                />
+            </CardContent>
+        </Card>
+    );
+};
+
+export default TimerCard;

--- a/frontend/src/settings/timers/TimerEditDialog.tsx
+++ b/frontend/src/settings/timers/TimerEditDialog.tsx
@@ -1,0 +1,275 @@
+import {
+    Box,
+    Button,
+    Checkbox,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    FormControl,
+    FormControlLabel,
+    InputLabel,
+    MenuItem,
+    Select,
+    TextField,
+    ToggleButton,
+    ToggleButtonGroup,
+    useMediaQuery,
+    useTheme,
+} from "@material-ui/core";
+import React, { FunctionComponent } from "react";
+import { Timer, TimerProperties } from "../../api";
+import { deepCopy } from "../../utils";
+import { timerActionLabels, weekdays } from "./TimerCard";
+import { StaticTimePicker } from "@material-ui/lab";
+import { TimerActionControlProps } from "./types";
+import {
+    FullCleanupControls,
+    GoToLocationControls,
+    SegmentCleanupControls,
+    validateParams,
+    ZoneCleanupControls,
+} from "./ActionControls";
+
+const actionControls: Record<
+    string,
+    React.ComponentType<TimerActionControlProps>
+> = {
+    full_cleanup: FullCleanupControls,
+    zone_cleanup: ZoneCleanupControls,
+    segment_cleanup: SegmentCleanupControls,
+    goto_location: GoToLocationControls,
+};
+
+type TimerDialogProps = {
+    timer: Timer;
+    timerProperties: TimerProperties;
+    open: boolean;
+    onSave: (newProps: Timer) => void;
+    onCancel: () => void;
+};
+
+const TimerEditDialog: FunctionComponent<TimerDialogProps> = ({
+    timer,
+    timerProperties,
+    open,
+    onSave,
+    onCancel,
+}): JSX.Element => {
+    const theme = useTheme();
+    const narrowScreen = useMediaQuery(theme.breakpoints.down("md"), {
+        noSsr: true,
+    });
+
+    const [validAction, setValidAction] = React.useState(false);
+    const [editTimer, setEditTimer] = React.useState<Timer>(timer);
+    React.useEffect(() => {
+        setEditTimer(timer);
+    }, [timer]);
+
+    React.useEffect(() => {
+        setValidAction(
+            validateParams[editTimer.action.type](editTimer.action.params)
+        );
+    }, [editTimer, open]);
+
+    const setActionParams = React.useCallback(
+        (newParams) => {
+            setValidAction(validateParams[editTimer.action.type](newParams));
+            const newTimer = deepCopy(editTimer);
+            newTimer.action.params = newParams;
+            setEditTimer(newTimer);
+        },
+        [editTimer]
+    );
+
+    const weekdayCheckboxes = React.useMemo(() => {
+        const checkboxes = weekdays.map((weekday, i) => {
+            if (!narrowScreen) {
+                return (
+                    <ToggleButton
+                        disabled={!editTimer.enabled}
+                        key={weekday}
+                        value={i}
+                        aria-label={weekday}
+                    >
+                        {weekday}
+                    </ToggleButton>
+                );
+            } else {
+                return (
+                    <FormControlLabel
+                        key={weekday}
+                        control={
+                            <Checkbox
+                                checked={editTimer.dow.indexOf(i) !== -1}
+                                onChange={(e) => {
+                                    const newTimer = deepCopy(editTimer);
+                                    if (e.target.checked) {
+                                        if (newTimer.dow.indexOf(i) === -1) {
+                                            newTimer.dow.push(i);
+                                        }
+                                    } else {
+                                        const idx = newTimer.dow.indexOf(i);
+                                        if (idx !== -1) {
+                                            newTimer.dow.splice(idx, 1);
+                                        }
+                                    }
+                                    setEditTimer(newTimer);
+                                }}
+                            />
+                        }
+                        label={weekday}
+                        aria-label={weekday}
+                    />
+                );
+            }
+        });
+
+        if (!narrowScreen) {
+            return (
+                <ToggleButtonGroup
+                    size={"small"}
+                    orientation={"horizontal"}
+                    value={editTimer.dow}
+                    onChange={(_, newWeekdays) => {
+                        if (!newWeekdays.length) {
+                            return;
+                        }
+                        const newTimer = deepCopy(editTimer);
+                        newTimer.dow = newWeekdays;
+                        setEditTimer(newTimer);
+                    }}
+                >
+                    {checkboxes}
+                </ToggleButtonGroup>
+            );
+        }
+
+        return checkboxes;
+    }, [editTimer, narrowScreen]);
+
+    const propertyMenuItems = React.useMemo(() => {
+        return timerProperties.supportedActions.map((action) => {
+            return (
+                <MenuItem key={action} value={action}>
+                    {timerActionLabels[action]}
+                </MenuItem>
+            );
+        });
+    }, [timerProperties]);
+
+    const ActionControl = actionControls[editTimer.action.type];
+
+    return (
+        <Dialog open={open} maxWidth={"lg"} fullScreen={narrowScreen}>
+            <DialogTitle>
+                {editTimer.id === "" ? "Add timer" : "Edit timer"}
+            </DialogTitle>
+            <DialogContent>
+                <FormControlLabel
+                    control={
+                        <Checkbox
+                            checked={editTimer.enabled}
+                            onChange={(e) => {
+                                const newTimer = deepCopy(editTimer);
+                                newTimer.enabled = e.target.checked;
+                                setEditTimer(newTimer);
+                            }}
+                        />
+                    }
+                    label="Enabled"
+                />
+
+                <Box pt={1} />
+
+                {weekdayCheckboxes}
+
+                <Box pt={1} />
+
+                <StaticTimePicker
+                    ampm={false}
+                    label={"Select time"}
+                    orientation={narrowScreen ? "portrait" : "landscape"}
+                    disabled={!editTimer.enabled}
+                    value={Date.UTC(
+                        2020,
+                        0,
+                        0,
+                        editTimer.hour,
+                        editTimer.minute,
+                        0,
+                        0
+                    )}
+                    onChange={(newValue) => {
+                        if (newValue && editTimer.enabled) {
+                            const newTimer = deepCopy(editTimer);
+                            const date = new Date(newValue);
+                            newTimer.hour = date.getUTCHours();
+                            newTimer.minute = date.getUTCMinutes();
+                            setEditTimer(newTimer);
+                        }
+                    }}
+                    renderInput={(params) => {
+                        return <TextField {...params} />;
+                    }}
+                />
+
+                <Box pt={1} />
+
+                <FormControl>
+                    <InputLabel id={editTimer.id + "_label"}>Action</InputLabel>
+                    <Select
+                        labelId={editTimer.id + "_label"}
+                        id={editTimer.id + "-action-select"}
+                        value={editTimer.action.type}
+                        label="Action"
+                        disabled={!editTimer.enabled}
+                        onChange={(e) => {
+                            const newTimer = deepCopy(editTimer);
+                            newTimer.action.type = e.target.value;
+                            newTimer.action.params = {};
+                            setEditTimer(newTimer);
+                            setValidAction(
+                                validateParams[newTimer.action.type](
+                                    newTimer.action.params
+                                )
+                            );
+                        }}
+                    >
+                        {propertyMenuItems}
+                    </Select>
+                </FormControl>
+
+                <Box pt={2} />
+
+                <ActionControl
+                    disabled={!editTimer.enabled}
+                    params={editTimer.action.params}
+                    setParams={setActionParams}
+                />
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    onClick={() => {
+                        setEditTimer(timer);
+                        onCancel();
+                    }}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    onClick={() => {
+                        onSave(editTimer);
+                    }}
+                    disabled={!validAction}
+                    autoFocus
+                >
+                    Save
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default TimerEditDialog;

--- a/frontend/src/settings/timers/Timers.tsx
+++ b/frontend/src/settings/timers/Timers.tsx
@@ -1,0 +1,147 @@
+import {
+    Box,
+    CircularProgress,
+    Container,
+    Fab,
+    Fade,
+    Grid,
+    styled,
+    Typography,
+} from "@material-ui/core";
+import AddIcon from "@material-ui/icons/Add";
+import React from "react";
+import {
+    Timer,
+    TimerInformation,
+    TimerProperties,
+    useTimerCreationMutation,
+    useTimerDeletionMutation,
+    useTimerInfoQuery,
+    useTimerModificationMutation,
+    useTimerPropertiesQuery,
+} from "../../api";
+import TimerCard from "./TimerCard";
+import TimerEditDialog from "./TimerEditDialog";
+import { deepCopy } from "../../utils";
+
+const FabBox = styled(Box)(({ theme }) => {
+    return {
+        position: "fixed",
+        bottom: theme.spacing(2),
+        right: theme.spacing(2),
+    };
+});
+
+const timerTemplate: Timer = {
+    id: "",
+    enabled: true,
+    dow: [1, 2, 3, 4, 5],
+    hour: 6,
+    minute: 0,
+    action: {
+        type: "full_cleanup",
+        params: {},
+    },
+};
+
+const Timers = (): JSX.Element => {
+    const {
+        data: timerData,
+        isLoading: timerDataLoading,
+        isError: timerDataError,
+    } = useTimerInfoQuery();
+
+    const {
+        data: timerPropertiesData,
+        isLoading: timerPropertiesLoading,
+        isError: timerPropertiesError,
+    } = useTimerPropertiesQuery();
+
+    const { mutate: createTimer } = useTimerCreationMutation();
+    const { mutate: modifyTimer } = useTimerModificationMutation();
+    const { mutate: deleteTimer } = useTimerDeletionMutation();
+
+    const [addTimerDialogOpen, setAddTimerDialogOpen] = React.useState(false);
+    const [addTimerData, setAddTimerData] =
+        React.useState<Timer>(timerTemplate);
+
+    const timerCards = React.useMemo(() => {
+        if (!timerPropertiesData || !timerData) {
+            return null;
+        }
+        return Object.values(timerData as TimerInformation).map((timer) => {
+            const id = timer.id;
+            const onDelete = () => {
+                deleteTimer(id);
+            };
+            const onSave = (timer: Timer) => {
+                modifyTimer(timer);
+            };
+
+            return (
+                <Grid item key={id}>
+                    <TimerCard
+                        onDelete={onDelete}
+                        onSave={onSave}
+                        timerProperties={timerPropertiesData as TimerProperties}
+                        timer={timer}
+                    />
+                </Grid>
+            );
+        });
+    }, [modifyTimer, deleteTimer, timerPropertiesData, timerData]);
+
+    const addTimer = React.useCallback(() => {
+        if (!timerPropertiesData) {
+            return;
+        }
+        setAddTimerData(deepCopy(timerTemplate));
+        setAddTimerDialogOpen(true);
+    }, [timerPropertiesData]);
+
+    if (timerDataLoading || timerPropertiesLoading) {
+        return (
+            <Fade
+                in
+                style={{
+                    transitionDelay: "500ms",
+                }}
+                unmountOnExit
+            >
+                <CircularProgress />
+            </Fade>
+        );
+    }
+
+    if (timerDataError || timerPropertiesError || !timerPropertiesData) {
+        return <Typography color="error">Error loading timers</Typography>;
+    }
+
+    return (
+        <Container>
+            <Box pt={2} />
+            <Grid container spacing={2}>
+                {timerCards}
+            </Grid>
+            <TimerEditDialog
+                timer={addTimerData}
+                timerProperties={timerPropertiesData}
+                open={addTimerDialogOpen}
+                onCancel={() => {
+                    setAddTimerDialogOpen(false);
+                }}
+                onSave={(timer) => {
+                    createTimer(timer);
+                    setAddTimerDialogOpen(false);
+                }}
+            />
+            <FabBox>
+                <Fab color="primary" aria-label="add" onClick={addTimer}>
+                    <AddIcon />
+                </Fab>
+            </FabBox>
+        </Container>
+    );
+};
+
+export default Timers;

--- a/frontend/src/settings/timers/index.ts
+++ b/frontend/src/settings/timers/index.ts
@@ -1,0 +1,3 @@
+import Timers from "./Timers";
+
+export default Timers;

--- a/frontend/src/settings/timers/types.ts
+++ b/frontend/src/settings/timers/types.ts
@@ -1,0 +1,5 @@
+export interface TimerActionControlProps {
+    disabled: boolean;
+    params: Record<string, unknown>;
+    setParams(newParams: Record<string, unknown>): void;
+}

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -27,3 +27,26 @@ export function convertSecondsToHumans(seconds: number): string {
 
     return humanReadableTimespan.trim();
 }
+
+// Adapted from https://gist.github.com/erikvullings/ada7af09925082cbb89f40ed962d475e
+export const deepCopy = <T>(target: T): T => {
+    if (target === null) {
+        return target;
+    }
+    if (target instanceof Date) {
+        return new Date(target.getTime()) as any;
+    }
+    if (target instanceof Array) {
+        const cp = [] as any[];
+        (target as any[]).forEach((v) => { cp.push(v); });
+        return cp.map((n: any) => {return deepCopy<any>(n)}) as any;
+    }
+    if (typeof target === 'object' && Object.keys(target).length !== 0) {
+        const cp = { ...(target as { [key: string]: any }) } as { [key: string]: any };
+        Object.keys(cp).forEach(k => {
+            cp[k] = deepCopy<any>(cp[k]);
+        });
+        return cp as T;
+    }
+    return target;
+};

--- a/old_frontend/lib/settings-timers.html
+++ b/old_frontend/lib/settings-timers.html
@@ -142,6 +142,14 @@
     <ons-list-title style="margin-top:5px;">"Do Not Disturb" - Timer</ons-list-title>
     <ons-list id="settings-dnd-timer-list"></ons-list>
 
+    <ons-row style="margin-top: 20px;">
+        <ons-col></ons-col>
+        <ons-col width="300px" vertical-align='center' style='text-align:center; max-width: 400px;'>
+            <strong>To edit cleaning timers you may use the <a href="/new_frontend/#/settings/timers">new UI</a>.</strong>
+        </ons-col>
+        <ons-col></ons-col>
+    </ons-row>
+
     <script>
       {
         let s = document.createElement('script');


### PR DESCRIPTION
## New UI for Timers

Type B:
- [ ] New capability
- [x] New core feature

# Description (Type B)

This adds a timer UI to the settings (available under `/#/settings/timers`). It's completely usable and supports all features available in Valetudo timers (different actions with their parameters).

Please be merciful, as Frontend stuff and especially TS are not my specialties. I'm open for feedback.

Also, sorry for reformatting `client.ts`, but there's no working autoformatting for the existing stuff.

![image](https://user-images.githubusercontent.com/8963459/132951908-8977f7fe-e9a6-471d-a056-37a9934a587c.png)

![image](https://user-images.githubusercontent.com/8963459/132951923-50d588f6-d9c6-433f-ae1b-829d39d86854.png)
