### PR TITLE
fix(ui): Timer UI timezone offset

### DIFF
--- a/frontend/src/settings/timers/TimerCard.tsx
+++ b/frontend/src/settings/timers/TimerCard.tsx
@@ -72,10 +72,9 @@ const TimerCard: FunctionComponent<TimerCardProps> = ({
     }, [timer]);
 
     const timeLabel = React.useMemo(() => {
-        // Year 0 breaks everything
-        const date = new Date(
-            Date.UTC(2020, 0, 0, timer.hour, timer.minute, 0, 0)
-        );
+        // Use today's date because the timezone offset may be dependent on the date (DST)
+        const date = new Date(Date.now());
+        date.setUTCHours(timer.hour, timer.minute, 0, 0);
         return (
             <>
                 <Typography

--- a/frontend/src/settings/timers/TimerEditDialog.tsx
+++ b/frontend/src/settings/timers/TimerEditDialog.tsx
@@ -159,6 +159,12 @@ const TimerEditDialog: FunctionComponent<TimerDialogProps> = ({
         });
     }, [timerProperties]);
 
+    const dateValue = React.useMemo(() => {
+        const date = new Date(Date.now());
+        date.setUTCHours(editTimer.hour, editTimer.minute, 0, 0);
+        return date;
+    }, [editTimer]);
+
     const ActionControl = actionControls[editTimer.action.type];
 
     return (
@@ -192,15 +198,7 @@ const TimerEditDialog: FunctionComponent<TimerDialogProps> = ({
                     label={"Select time"}
                     orientation={narrowScreen ? "portrait" : "landscape"}
                     disabled={!editTimer.enabled}
-                    value={Date.UTC(
-                        2020,
-                        0,
-                        0,
-                        editTimer.hour,
-                        editTimer.minute,
-                        0,
-                        0
-                    )}
+                    value={dateValue}
                     onChange={(newValue) => {
                         if (newValue && editTimer.enabled) {
                             const newTimer = deepCopy(editTimer);


### PR DESCRIPTION
## Timer UI timezone offset may be wrongly calculated

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation

# Description (Type A)

Fix the UTC timezone offset. I forgot that the offset depends on the date, in case you're in a country with DST.

Yes, technically not including the date would be even better, but the Material UI TimePicker requires a date value.