### PR TITLE
fix(ui): Improve word breaks in MQTT topic preview

### DIFF
--- a/frontend/src/settings/MQTT.tsx
+++ b/frontend/src/settings/MQTT.tsx
@@ -260,13 +260,13 @@ const MQTT = (): JSX.Element => {
                             }} ref={topicElement}>
                                 {mqttConfiguration.customizations.topicPrefix || mqttProperties.defaults.customizations.topicPrefix}
                             </span>
-                        /
+                        /<wbr/>
                             <span style={{
                                 color: theme.palette.secondary.main
                             }} ref={identifierElement}>
                                 {mqttConfiguration.identity.identifier || mqttProperties.defaults.identity.identifier}
                             </span>
-                            /BatteryStateAttribute/level
+                            /<wbr/>BatteryStateAttribute/<wbr/>level
                         </span>
                     </Typography>
                     <br/>


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature

# Description (Type A)

Adds `wbr`-Tags to indicate better places for word-breaks in MQTT topic preview.

Before:

![image](https://user-images.githubusercontent.com/8963459/133669248-ab37b9aa-a5e2-49bc-891f-1f36ea983ff4.png)

After:

![image](https://user-images.githubusercontent.com/8963459/133669184-30735664-d802-4ea2-83d6-3046238f5490.png)

