### PR TITLE
Timer action controls Memo dependency

### DIFF
--- a/frontend/src/settings/timers/ActionControls.tsx
+++ b/frontend/src/settings/timers/ActionControls.tsx
@@ -114,7 +114,7 @@ export const SegmentCleanupControls: FunctionComponent<TimerActionControlProps> 
     ({ disabled, params, setParams }) => {
         const segmentIds: Array<string> = React.useMemo(() => {
             return (params.segment_ids as Array<string>) || [];
-        }, [params]);
+        }, [params.segment_ids]);
         const iterationCount: number = (params.iterations as number) || 1;
         const customOrder: boolean = (params.custom_order as boolean) ?? false;
 


### PR DESCRIPTION
## Timer action controls Memo dependency

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature

# Description (Type A)

This fixes a subtle bug in timers in combination with segment cleanup - Adding a segment didn't always work any could result in it being added twice after pushing the button a second time. That also broke Reacts `key`-Requirements. This fix makes `React.useMemo` always compare the array and not the entire action params object.