### PR TITLE
Log with SSE and display in new UI

### DIFF
--- a/backend/lib/Logger.js
+++ b/backend/lib/Logger.js
@@ -139,4 +139,8 @@ class Logger {
     }
 }
 
+Logger.EVENTS = {
+    LogMessage: "LogMessage",
+};
+
 module.exports = Logger;

--- a/backend/lib/robots/mock/MockRobot.js
+++ b/backend/lib/robots/mock/MockRobot.js
@@ -1,9 +1,9 @@
 const capabilities = require("./capabilities");
+const DustBinFullValetudoEvent = require("../../valetudo_events/events/DustBinFullValetudoEvent");
+const ErrorStateValetudoEvent = require("../../valetudo_events/events/ErrorStateValetudoEvent");
+const PendingMapChangeValetudoEvent = require("../../valetudo_events/events/PendingMapChangeValetudoEvent");
 const ValetudoRobot = require("../../core/ValetudoRobot");
 const { MapLayer, PointMapEntity, ValetudoMap } = require("../../entities/map");
-const DustBinFullValetudoEvent = require("../../valetudo_events/events/DustBinFullValetudoEvent");
-const PendingMapChangeValetudoEvent = require("../../valetudo_events/events/PendingMapChangeValetudoEvent");
-const ErrorStateValetudoEvent = require("../../valetudo_events/events/ErrorStateValetudoEvent");
 
 class MockRobot extends ValetudoRobot {
     /**

--- a/backend/lib/webserver/WebServer.js
+++ b/backend/lib/webserver/WebServer.js
@@ -104,10 +104,11 @@ class WebServer {
         }
 
         this.robotRouter = new RobotRouter({robot: this.robot, enableDebugCapability: enableDebugCapability, validator: this.validator});
+        this.valetudoRouter = new ValetudoRouter({config: this.config, robot: this.robot, validator: this.validator});
 
         this.app.use("/api/v2/robot/", this.robotRouter.getRouter());
 
-        this.app.use("/api/v2/valetudo/", new ValetudoRouter({config: this.config, robot: this.robot, validator: this.validator}).getRouter());
+        this.app.use("/api/v2/valetudo/", this.valetudoRouter.getRouter());
 
         this.app.use("/api/v2/ntpclient/", new NTPClientRouter({config: this.config, ntpClient: options.ntpClient, validator: this.validator}).getRouter());
 
@@ -211,6 +212,7 @@ class WebServer {
         return new Promise((resolve, reject) => {
             Logger.debug("Webserver shutdown in progress...");
             this.robotRouter.shutdown();
+            this.valetudoRouter.shutdown();
 
             //closing the server
             this.webserver.close(() => {

--- a/backend/lib/webserver/doc/ValetudoRouter.openapi.json
+++ b/backend/lib/webserver/doc/ValetudoRouter.openapi.json
@@ -47,6 +47,27 @@
       }
     }
   },
+  "/api/v2/valetudo/log/content/sse": {
+    "get": {
+      "tags": [
+        "Valetudo"
+      ],
+      "summary": "Get new log lines (SSE events)",
+      "description": "Retrieve new log lines.\n\nNote! This endpoint provides SSE events. Swagger does not support it.\nNote! This endpoint provides raw text, do not try to decode it as JSON.",
+      "responses": {
+        "200": {
+          "description": "Ok",
+          "content": {
+            "text/event-stream": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "/api/v2/valetudo/log/level": {
     "get": {
       "tags": [

--- a/frontend/src/AppRouter.tsx
+++ b/frontend/src/AppRouter.tsx
@@ -2,7 +2,7 @@ import {HashRouter, Redirect, Route, Switch} from "react-router-dom";
 import Div100vh from "react-div-100vh";
 import HomePage from "./HomePage";
 import SettingsRouter from "./settings";
-import {styled} from "@material-ui/core";
+import {Box, styled} from "@material-ui/core";
 import ValetudoAppBar from "./compontents/ValetudoAppBar";
 import React from "react";
 
@@ -31,6 +31,7 @@ const AppRouter = (): JSX.Element => {
                             <HomePage/>
                         </Route>
                         <Route path="/settings">
+                            <Box pt={2}/>
                             <SettingsRouter/>
                         </Route>
                         <Route path="*">

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -234,3 +234,12 @@ export interface ValetudoEventInteractionContext {
     id: string;
     interaction: ValetudoEventInteraction;
 }
+
+export interface LogLevel {
+    current: string;
+    presets: Array<string>;
+}
+
+export interface SetLogLevel {
+    level: string;
+}

--- a/frontend/src/compontents/ValetudoAppBar.tsx
+++ b/frontend/src/compontents/ValetudoAppBar.tsx
@@ -17,6 +17,7 @@ import {
     AccessTime as TimeIcon,
     Home as HomeIcon,
     Info as InfoIcon,
+    List as ListIcon,
     Menu as MenuIcon,
     SvgIconComponent
 } from "@material-ui/icons";
@@ -67,6 +68,14 @@ const menuTree: Array<MenuEntry | MenuSubheader> = [
     },
     {
         kind: "MenuEntry",
+        routeMatch: "/settings/log",
+        title: "Log",
+        showInMenu: true,
+        menuIcon: ListIcon,
+        menuText: "Log"
+    },
+    {
+        kind: "MenuEntry",
         routeMatch: "/settings/timers",
         title: "Timers",
         showInMenu: true,
@@ -86,7 +95,14 @@ const menuTree: Array<MenuEntry | MenuSubheader> = [
 const ValetudoAppBar = (): JSX.Element => {
     const [drawerOpen, setDrawerOpen] = React.useState<boolean>(false);
 
-    const routeMatch = useRouteMatch(["/settings/about", "/settings/timers", "/settings/mqtt", "/"]);
+    const routeMatch = useRouteMatch([
+        // Order is important here, deep => shallow
+        "/settings/about",
+        "/settings/log",
+        "/settings/timers",
+        "/settings/mqtt",
+        "/"
+    ]);
     const currentTab = routeMatch?.path;
 
     const pageTitle = React.useMemo(() => {

--- a/frontend/src/settings/About.tsx
+++ b/frontend/src/settings/About.tsx
@@ -1,5 +1,4 @@
 import {
-    Box,
     Button,
     ButtonGroup,
     Card,
@@ -456,7 +455,6 @@ const About = (): JSX.Element => {
 
     return (
         <Container>
-            <Box pt={2}/>
             <Grid container spacing={2}>
                 <Grid item>
                     <Card>

--- a/frontend/src/settings/Log.tsx
+++ b/frontend/src/settings/Log.tsx
@@ -1,0 +1,174 @@
+import {
+    alpha,
+    Container,
+    FormControl,
+    Grid,
+    IconButton,
+    InputBase,
+    InputLabel,
+    MenuItem,
+    Select,
+    styled,
+    TextField,
+    Typography,
+} from "@material-ui/core";
+import {Refresh as RefreshIcon, FilterAlt as FilterAltIcon} from "@material-ui/icons";
+import React from "react";
+import {useLogLevelMutation, useLogLevelQuery, useValetudoLogQuery} from "../api";
+
+const Search = styled("div")(({theme}) => {
+    return {
+        position: "relative",
+        borderRadius: theme.shape.borderRadius,
+        backgroundColor: alpha(theme.palette.common.white, 0.15),
+        "&:hover": {
+            backgroundColor: alpha(theme.palette.common.white, 0.25),
+        },
+        marginRight: theme.spacing(2),
+        marginLeft: 0,
+        width: "100%",
+        flexGrow: 1,
+        [theme.breakpoints.up("sm")]: {
+            marginLeft: theme.spacing(3),
+            width: "auto",
+        },
+    };
+});
+
+const SearchIconWrapper = styled("div")(({theme}) => {
+    return {
+        padding: theme.spacing(0, 2),
+        height: "100%",
+        position: "absolute",
+        pointerEvents: "none",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+    };
+});
+
+const StyledInputBase = styled(InputBase)(({theme}) => {
+    return {
+        color: "inherit",
+        flexGrow: 1,
+        display: "flex",
+        "& .MuiInputBase-input": {
+            padding: theme.spacing(1, 1, 1, 0),
+            // vertical padding + font size from searchIcon
+            paddingLeft: `calc(1em + ${theme.spacing(4)})`,
+            transition: theme.transitions.create("width"),
+            width: "100%",
+            flexGrow: 1,
+            [theme.breakpoints.up("md")]: {
+                width: "20ch",
+            },
+        },
+    };
+});
+
+
+const Log = (): JSX.Element => {
+    const [filter, setFilter] = React.useState("");
+    const logRef = React.useRef(null);
+
+    const {
+        data: logData,
+        isError: logError,
+        refetch: logRefetch,
+    } = useValetudoLogQuery();
+
+    const {
+        data: logLevel,
+        isError: logLevelError,
+        refetch: logLevelRefetch
+    } = useLogLevelQuery();
+
+    React.useEffect(() => {
+        const currentLogRef = logRef.current;
+        if (logData && currentLogRef) {
+            const textArea = currentLogRef as HTMLTextAreaElement;
+            textArea.scrollTop = textArea.scrollHeight;
+        }
+    }, [logData]);
+
+    const {mutate: mutateLogLevel} = useLogLevelMutation();
+
+    const logLines = React.useMemo(() => {
+        if (logError || logLevelError) {
+            return <Typography color="error">Error loading log</Typography>;
+        }
+
+        const lowerFilter = filter.toLowerCase();
+        const filteredData = filter ? logData?.split("\n").filter(l => {
+            return l.toLowerCase().includes(lowerFilter);
+        }).join("\n") : logData;
+
+        return (
+            <React.Fragment>
+                <Grid container alignItems={"center"} columnSpacing={1} rowSpacing={2} columns={{xs: 4, sm: 12}}
+                    sx={{mb: 2}}>
+                    <Grid item xs={4} sm={9}>
+                        <Search>
+                            <SearchIconWrapper>
+                                <FilterAltIcon/>
+                            </SearchIconWrapper>
+                            <StyledInputBase
+                                placeholder="Filter…"
+                                inputProps={{
+                                    "aria-label": "filter",
+                                    value: filter,
+                                    onChange: (e) => {
+                                        setFilter((e.target as HTMLInputElement).value);
+                                    }
+                                }}
+                            />
+                        </Search>
+                    </Grid>
+                    <Grid item xs={3} sm={2}>
+                        <FormControl fullWidth>
+                            <InputLabel id="log-level-selector">Log level</InputLabel>
+                            <Select
+                                labelId="log-level-selector"
+                                value={logLevel?.current || "info"}
+                                label="Log level"
+                                onChange={(e) => {
+                                    mutateLogLevel({
+                                        level: e.target.value as string
+                                    });
+                                }}
+                            >
+                                {logLevel?.presets.map(preset => {
+                                    return <MenuItem key={preset} value={preset}>{preset}</MenuItem>;
+                                })}
+                            </Select>
+                        </FormControl>
+                    </Grid>
+                    <Grid item xs={1} sm={1}>
+                        <IconButton
+                            onClick={() => {
+                                logLevelRefetch().then();
+                                logRefetch().then();
+                            }}
+                        >
+                            <RefreshIcon/>
+                        </IconButton>
+                    </Grid>
+                </Grid>
+                <TextField focused InputProps={{
+                    readOnly: true,
+                    sx: {
+                        fontFamily: "monospace"
+                    },
+                }} inputRef={logRef} fullWidth multiline label="Log content" value={filteredData} rows={15}/>
+            </React.Fragment>
+        );
+    }, [logData, logError, logRefetch, logLevel, logLevelError, logLevelRefetch, mutateLogLevel, filter, setFilter]);
+
+    return (
+        <Container>
+            {logLines}
+        </Container>
+    );
+};
+
+export default Log;

--- a/frontend/src/settings/MQTT.tsx
+++ b/frontend/src/settings/MQTT.tsx
@@ -175,8 +175,6 @@ const MQTT = (): JSX.Element => {
 
     return (
         <Container>
-            <Box pt={2}/>
-
             <GroupBox title={"MQTT enabled"} checked={mqttConfiguration.enabled} onChange={(e) => {
                 modifyMQTTConfig(e.target.checked, ["enabled"]);
             }}>

--- a/frontend/src/settings/SettingsRouter.tsx
+++ b/frontend/src/settings/SettingsRouter.tsx
@@ -3,6 +3,7 @@ import {useRouteMatch} from "react-router-dom";
 import About from "./About";
 import Timers from "./timers";
 import MQTT from "./MQTT";
+import Log from "./Log";
 
 const SettingsRouter = (): JSX.Element => {
     const {path} = useRouteMatch();
@@ -11,6 +12,9 @@ const SettingsRouter = (): JSX.Element => {
         <Switch>
             <Route exact path={path + "/about"}>
                 <About/>
+            </Route>
+            <Route exact path={path + "/log"}>
+                <Log/>
             </Route>
             <Route exact path={path + "/timers"}>
                 <Timers/>

--- a/frontend/src/settings/timers/Timers.tsx
+++ b/frontend/src/settings/timers/Timers.tsx
@@ -119,7 +119,6 @@ const Timers = (): JSX.Element => {
 
     return (
         <Container>
-            <Box pt={2} />
             <Grid container spacing={2}>
                 {timerCards}
             </Grid>


### PR DESCRIPTION
## Log with SSE and display in new UI

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature

# Description (Type A)
## UI
Not great, still just a simple `textarea`. But at least usable and filterable.

![image](https://user-images.githubusercontent.com/8963459/133838483-2f3c8307-846e-42be-bb09-a005cf223b1f.png)

## SSE
Added `/valetudo/log/content/sse`, which generates an event on every new log line.
