### PR TITLE
feat(ui): Manual control

### DIFF
--- a/backend/lib/core/capabilities/ManualControlCapability.js
+++ b/backend/lib/core/capabilities/ManualControlCapability.js
@@ -38,6 +38,14 @@ class ManualControlCapability extends Capability {
 
     /**
      * @abstract
+     * @return {Promise<boolean>}
+     */
+    async manualControlActive() {
+        throw new NotImplementedError();
+    }
+
+    /**
+     * @abstract
      * @param {ValetudoManualControlMovementCommandType} movementCommand
      * @returns {Promise<void>}
      */

--- a/backend/lib/robots/dreame/capabilities/DreameManualControlCapability.js
+++ b/backend/lib/robots/dreame/capabilities/DreameManualControlCapability.js
@@ -75,6 +75,13 @@ class DreameManualControlCapability extends ManualControlCapability {
         this.active = false;
     }
 
+    /**
+     * @returns {Promise<boolean>}
+     */
+    async manualControlActive() {
+        return this.active;
+    }
+
     async sendAndScheduleKeepAlive() {
         clearTimeout(this.keepAliveTimeout);
 

--- a/backend/lib/robots/mock/MockRobot.js
+++ b/backend/lib/robots/mock/MockRobot.js
@@ -38,6 +38,7 @@ class MockRobot extends ValetudoRobot {
         this.registerCapability(new capabilities.MockAutoEmptyDockAutoEmptyControlCapability({robot: this}));
         this.registerCapability(new capabilities.MockMappingPassCapability({robot: this}));
         this.registerCapability(new capabilities.MockVoicePackManagementCapability({robot: this}));
+        this.registerCapability(new capabilities.MockManualControlCapability({robot: this}));
 
         // Raise events to make them visible in the UI
         options.valetudoEventStore.raise(new DustBinFullValetudoEvent({}));
@@ -143,7 +144,7 @@ class MockRobot extends ValetudoRobot {
     buildCharger() {
         return new PointMapEntity({
             type: PointMapEntity.TYPE.CHARGER_LOCATION,
-            points: [this.mockMap.range.min * this.mockMap.pixelSize + 20, this.mockMap.range.min * this.mockMap.pixelSize]
+            points: [this.mockMap.range.min * this.mockMap.pixelSize + 50, this.mockMap.range.min * this.mockMap.pixelSize]
         });
     }
 
@@ -153,7 +154,10 @@ class MockRobot extends ValetudoRobot {
     buildRobot() {
         return new PointMapEntity({
             type: PointMapEntity.TYPE.ROBOT_POSITION,
-            points: [this.mockMap.range.min * this.mockMap.pixelSize + 20, this.mockMap.range.min * this.mockMap.pixelSize + 20]
+            points: [this.mockMap.range.min * this.mockMap.pixelSize + 50, this.mockMap.range.min * this.mockMap.pixelSize + 50],
+            metaData: {
+                angle: 180
+            }
         });
     }
 }

--- a/backend/lib/robots/mock/capabilities/index.js
+++ b/backend/lib/robots/mock/capabilities/index.js
@@ -9,6 +9,7 @@ module.exports = {
     MockGoToLocationCapability: require("./MockGoToLocationCapability"),
     MockKeyLockCapability: require("./MockKeyLockCapability"),
     MockLocateCapability: require("./MockLocateCapability"),
+    MockManualControlCapability: require("./MockManualControlCapability"),
     MockMapResetCapability: require("./MockMapResetCapability"),
     MockMapSegmentationCapability: require("./MockMapSegmentationCapability"),
     MockMappingPassCapability: require("./MockMappingPassCapability"),

--- a/backend/lib/robots/viomi/capabilities/ViomiManualControlCapability.js
+++ b/backend/lib/robots/viomi/capabilities/ViomiManualControlCapability.js
@@ -61,6 +61,13 @@ class ViomiManualControlCapability extends ManualControlCapability {
     }
 
     /**
+     * @returns {Promise<boolean>}
+     */
+    async manualControlActive() {
+        return this.isInManualControlMode();
+    }
+
+    /**
      * @param {import("../../../core/capabilities/ManualControlCapability").ValetudoManualControlMovementCommandType} movementCommand
      * @returns {Promise<void>}
      */

--- a/backend/lib/webserver/capabilityRouters/ManualControlCapabilityRouter.js
+++ b/backend/lib/webserver/capabilityRouters/ManualControlCapabilityRouter.js
@@ -7,6 +7,12 @@ const CapabilityRouter = require("./CapabilityRouter");
 class ManualControlCapabilityRouter extends CapabilityRouter {
 
     initRoutes() {
+        this.router.get("/", async (req, res) => {
+            res.json({
+                enabled: await this.capability.manualControlActive()
+            });
+        });
+
         this.router.put("/", async (req, res) => {
             if (req.body && req.body.action) {
                 switch (req.body.action) {

--- a/backend/lib/webserver/capabilityRouters/doc/ManualControlCapabilityRouter.openapi.json
+++ b/backend/lib/webserver/capabilityRouters/doc/ManualControlCapabilityRouter.openapi.json
@@ -1,5 +1,28 @@
 {
   "/api/v2/robot/capabilities/ManualControlCapability": {
+    "get": {
+      "tags": [
+        "ManualControlCapability"
+      ],
+      "summary": "Get manual control status",
+      "responses": {
+        "200": {
+          "description": "Ok",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "put": {
       "tags": [
         "ManualControlCapability"
@@ -92,7 +115,16 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object"
+                "type": "object",
+                "properties": {
+                  "supportedMovementCommands": {
+                    "type": "array",
+                    "description": "Supported movement commands",
+                    "items": {
+                      "$ref": "#/components/schemas/ValetudoManualControlMovementCommandType"
+                    }
+                  }
+                }
               }
             }
           }

--- a/frontend/src/HomePage.tsx
+++ b/frontend/src/HomePage.tsx
@@ -3,13 +3,8 @@ import ControlsBody from "./controls";
 import ControlsBottomSheet from "./controls/ControlsBottomSheet";
 import {useIsMobileView} from "./hooks";
 import MapPage from "./map";
+import {FullHeightGrid} from "./components/FullHeightGrid";
 
-const RootGrid = styled(Grid)(({ theme }) => {
-    return {
-        height: `calc(100% - ${theme.mixins.toolbar.minHeight}px)`,
-        flexWrap: "nowrap",
-    };
-});
 const ScrollableGrid = styled(Grid)({
     overflow: "auto",
 });
@@ -28,7 +23,7 @@ const HomePage = (): JSX.Element => {
     }
 
     return (
-        <RootGrid container direction="row" justifyContent="space-evenly">
+        <FullHeightGrid container direction="row" justifyContent="space-evenly">
             <Grid item sm md lg xl>
                 <MapPage/>
             </Grid>
@@ -38,7 +33,7 @@ const HomePage = (): JSX.Element => {
                     <ControlsBody/>
                 </Box>
             </ScrollableGrid>
-        </RootGrid>
+        </FullHeightGrid>
     );
 };
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,6 +9,8 @@ import {
     GitHubRelease,
     GoToLocation,
     LogLevel,
+    ManualControlInteraction,
+    ManualControlProperties,
     MapSegmentationActionRequestParameters,
     MapSegmentationProperties,
     MQTTConfiguration,
@@ -632,6 +634,32 @@ export const sendWifiConfiguration = async (configuration: WifiConfiguration): P
         .then(({ status }) => {
             if (status !== 200) {
                 throw new Error("Could not set Wifi configuration");
+            }
+        });
+};
+
+export const fetchManualControlState = async (): Promise<SimpleToggleState> => {
+    return valetudoAPI
+        .get<SimpleToggleState>(`/robot/capabilities/${Capability.ManualControl}`)
+        .then(({ data }) => {
+            return data;
+        });
+};
+
+export const fetchManualControlProperties = async (): Promise<ManualControlProperties> => {
+    return valetudoAPI
+        .get<ManualControlProperties>(`/robot/capabilities/${Capability.ManualControl}/properties`)
+        .then(({ data }) => {
+            return data;
+        });
+};
+
+export const sendManualControlInteraction = async (interaction: ManualControlInteraction): Promise<void> => {
+    await valetudoAPI
+        .put(`/robot/capabilities/${Capability.ManualControl}`, interaction)
+        .then(({ status }) => {
+            if (status !== 200) {
+                throw new Error("Could not send manual control interaction");
             }
         });
 };

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -19,6 +19,8 @@ import {
     fetchGoToLocationPresets,
     fetchKeyLockState,
     fetchLatestGitHubRelease,
+    fetchManualControlProperties,
+    fetchManualControlState,
     fetchMap,
     fetchMapSegmentationProperties,
     fetchMQTTConfiguration,
@@ -55,6 +57,7 @@ import {
     sendGoToLocationPresetCommand,
     sendKeyLockEnable,
     sendLocateCommand,
+    sendManualControlInteraction,
     sendMapReset,
     sendMQTTConfiguration,
     sendObstacleAvoidanceModeEnable,
@@ -84,6 +87,7 @@ import {
     Capability,
     ConsumableId,
     DoNotDisturbConfiguration,
+    ManualControlInteraction,
     MapSegmentationActionRequestParameters,
     MQTTConfiguration,
     Point,
@@ -128,6 +132,8 @@ enum CacheKey {
     AutoEmptyDockAutoEmpty = "auto_empty_dock_auto_empty",
     DoNotDisturb = "do_not_disturb",
     Wifi = "wifi",
+    ManualControl = "manual_control",
+    ManualControlProperties = "manual_control_properties",
 }
 
 const useOnCommandError = (capability: Capability): ((error: unknown) => void) => {
@@ -786,6 +792,29 @@ export const useWifiConfigurationMutation = () => {
         CacheKey.Wifi,
         (configuration: WifiConfiguration) => {
             return sendWifiConfiguration(configuration).then(fetchWifiConfiguration);
+        }
+    );
+};
+
+export const useManualControlStateQuery = () => {
+    return useQuery(CacheKey.ManualControl, fetchManualControlState, {
+        staleTime: 10_000,
+        refetchInterval: 10_000
+    });
+};
+
+export const useManualControlPropertiesQuery = () => {
+    return useQuery(CacheKey.ManualControlProperties, fetchManualControlProperties, {
+        staleTime: Infinity
+    });
+};
+
+export const useManualControlInteraction = () => {
+    return useValetudoFetchingMutation(
+        useOnCommandError(Capability.ManualControl),
+        CacheKey.ManualControl,
+        (interaction: ManualControlInteraction) => {
+            return sendManualControlInteraction(interaction).then(fetchManualControlState);
         }
     );
 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -313,3 +313,16 @@ export interface WifiConfiguration {
         frequency: "2.4ghz" | "5ghz";
     };
 }
+
+export type ManualControlAction = "enable" | "disable" | "move";
+
+export type ManualControlCommand = "forward" | "backward" | "rotate_clockwise" | "rotate_counterclockwise";
+
+export interface ManualControlProperties {
+    supportedMovementCommands: Array<ManualControlCommand>;
+}
+
+export interface ManualControlInteraction {
+    action: ManualControlAction;
+    movementCommand?: ManualControlCommand;
+}

--- a/frontend/src/components/FullHeightGrid.tsx
+++ b/frontend/src/components/FullHeightGrid.tsx
@@ -1,0 +1,9 @@
+import {Grid, styled} from "@mui/material";
+
+export const FullHeightGrid = styled(Grid)(({ theme }) => {
+    return {
+        height: `calc(100% - ${theme.mixins.toolbar.minHeight}px)`,
+        width: "100%",
+        flexWrap: "nowrap",
+    };
+});

--- a/frontend/src/map/MapPage.tsx
+++ b/frontend/src/map/MapPage.tsx
@@ -1,6 +1,7 @@
 import {Box, Button, CircularProgress, styled, Typography,} from "@mui/material";
 import {useRobotMapQuery} from "../api";
 import MapLayers from "./layers";
+import {MapLayersPropTypes} from "./layers/MapLayers";
 
 const Container = styled(Box)({
     flex: "1",
@@ -11,7 +12,7 @@ const Container = styled(Box)({
     alignItems: "center",
 });
 
-const MapPage = (): JSX.Element => {
+const MapPage = (props: MapLayersPropTypes): JSX.Element => {
     const {
         data: mapData,
         isLoading: mapIsLoading,
@@ -49,7 +50,7 @@ const MapPage = (): JSX.Element => {
         );
     }
 
-    return <MapLayers data={mapData} padding={4 * 8}/>;
+    return <MapLayers data={mapData} padding={4 * 8} {...props}/>;
 };
 
 export default MapPage;

--- a/frontend/src/map/layers/MapLayers.tsx
+++ b/frontend/src/map/layers/MapLayers.tsx
@@ -10,7 +10,7 @@ import {
 } from "@mui/material";
 import React from "react";
 import GoLayer from "./GoLayer";
-import { MapLayersProps } from "./types";
+import {MapLayersProps} from "./types";
 import {
     BorderStyle as ZonesIcon,
     LayersOutlined as SegmentsIcon,
@@ -18,12 +18,12 @@ import {
     Visibility as ViewIcon,
 } from "@mui/icons-material";
 import ViewLayer from "./ViewLayer";
-import { Capability } from "../../api";
-import { useCapabilitiesSupported } from "../../CapabilitiesProvider";
+import {Capability} from "../../api";
+import {useCapabilitiesSupported} from "../../CapabilitiesProvider";
 import SegmentsLayer from "./SegmentsLayer";
 import ZonesLayer from "./ZonesLayer";
 
-const StyledBackdrop = styled(Backdrop)(({ theme }) => {
+const StyledBackdrop = styled(Backdrop)(({theme}) => {
     return {
         zIndex: theme.zIndex.speedDial - 1,
     };
@@ -35,7 +35,7 @@ const Root = styled(Box)({
     height: "100%",
 });
 
-const StyledSpeedDial = styled(SpeedDial)(({ theme }) => {
+const StyledSpeedDial = styled(SpeedDial)(({theme}) => {
     return {
         position: "absolute",
         pointerEvents: "none",
@@ -62,13 +62,17 @@ const layerToComponent: Record<Layer, React.ComponentType<MapLayersProps>> = {
     Zones: ZonesLayer,
 };
 const layerToIcon: Record<Layer, JSX.Element> = {
-    View: <ViewIcon />,
-    Go: <GoIcon />,
-    Segments: <SegmentsIcon />,
-    Zones: <ZonesIcon />,
+    View: <ViewIcon/>,
+    Go: <GoIcon/>,
+    Segments: <SegmentsIcon/>,
+    Zones: <ZonesIcon/>,
 };
 
-const MapLayers = (props: Omit<MapLayersProps, "onDone">): JSX.Element => {
+export interface MapLayersPropTypes {
+    layer?: Layer;
+}
+
+const MapLayers = (props: Omit<MapLayersProps, "onDone"> & MapLayersPropTypes): JSX.Element => {
     const [
         goToLocation,
         mapSegmentation,
@@ -79,7 +83,7 @@ const MapLayers = (props: Omit<MapLayersProps, "onDone">): JSX.Element => {
         Capability.ZoneCleaning
     );
     const layers = React.useMemo<Layer[]>(() => {
-        const layers : Array<Layer> = [
+        const layers: Array<Layer> = [
             "View"
         ];
 
@@ -98,7 +102,7 @@ const MapLayers = (props: Omit<MapLayersProps, "onDone">): JSX.Element => {
     },
     [goToLocation, mapSegmentation, zoneCleaning]
     );
-    const [selectedLayer, setSelectedLayer] = React.useState<Layer>("View");
+    const [selectedLayer, setSelectedLayer] = React.useState<Layer>(props.layer ?? "View");
     const [open, setOpen] = React.useState(false);
 
     const selectLayer = (layer: Layer) => {
@@ -134,42 +138,46 @@ const MapLayers = (props: Omit<MapLayersProps, "onDone">): JSX.Element => {
         []
     );
 
-    const LayerComponent = layerToComponent[selectedLayer];
+    const LayerComponent = layerToComponent[props.layer ?? selectedLayer];
 
     if (layers.length === 1) {
         return (
             <Root>
-                <LayerComponent {...props} onDone={selectLayer("View")} />
+                <LayerComponent {...props} onDone={selectLayer("View")}/>
             </Root>
         );
     }
 
+    const showSpeedDial = !props.layer;
+
     return (
         <Root>
-            <StyledBackdrop open={open} />
-            <LayerComponent {...props} onDone={selectLayer("View")} />
-            <StyledSpeedDial
-                direction="down"
-                color="inherit"
-                open={open}
-                icon={layerToIcon[selectedLayer]}
-                onOpen={handleOpen}
-                onClose={handleClose}
-                ariaLabel="MapLayer SpeedDial"
-                FabProps={{ size: "small" }}
-            >
-                {layers.map((layer) => {
-                    return (
-                        <SpeedDialAction
-                            key={layer}
-                            tooltipOpen
-                            tooltipTitle={layer}
-                            icon={layerToIcon[layer]}
-                            onClick={selectLayer(layer)}
-                        />
-                    );
-                })}
-            </StyledSpeedDial>
+            <StyledBackdrop open={showSpeedDial && open}/>
+            <LayerComponent {...props} onDone={selectLayer("View")}/>
+            {showSpeedDial && (
+                <StyledSpeedDial
+                    direction="down"
+                    color="inherit"
+                    open={open}
+                    icon={layerToIcon[props.layer ?? selectedLayer]}
+                    onOpen={handleOpen}
+                    onClose={handleClose}
+                    ariaLabel="MapLayer SpeedDial"
+                    FabProps={{size: "small"}}
+                >
+                    {layers.map((layer) => {
+                        return (
+                            <SpeedDialAction
+                                key={layer}
+                                tooltipOpen
+                                tooltipTitle={layer}
+                                icon={layerToIcon[layer]}
+                                onClick={selectLayer(layer)}
+                            />
+                        );
+                    })}
+                </StyledSpeedDial>
+            )}
         </Root>
     );
 };

--- a/frontend/src/robot/Consumables.tsx
+++ b/frontend/src/robot/Consumables.tsx
@@ -190,9 +190,7 @@ const DustbinConsumables: FunctionComponent<ConsumableVisualizerProps> = ({
     );
 };
 
-const Consumables = (): JSX.Element => {
-    const [consumablesSupported] = useCapabilitiesSupported(Capability.ConsumableMonitoring);
-
+const ConsumablesInternal = (): JSX.Element => {
     const {
         data: consumablesData,
         isLoading: consumablesLoading,
@@ -202,15 +200,11 @@ const Consumables = (): JSX.Element => {
 
     const [selectedConsumable, setSelectedConsumable] = React.useState<null | ConsumableId>(null);
 
-    const consumables = React.useMemo(() => {
+    return React.useMemo(() => {
         if (consumablesLoading) {
             return (
                 <LoadingFade/>
             );
-        }
-
-        if (!consumablesSupported) {
-            return <Typography color="error">This robot does not support consumables.</Typography>;
         }
 
         if (consumablesError || !consumablesData) {
@@ -291,11 +285,17 @@ const Consumables = (): JSX.Element => {
                 </Grid>
             </>
         );
-    }, [consumablesSupported, consumablesData, consumablesLoading, consumablesError, consumablesRefetch, selectedConsumable]);
+    }, [consumablesData, consumablesLoading, consumablesError, consumablesRefetch, selectedConsumable]);
+};
+
+const Consumables = (): JSX.Element => {
+    const [supported] = useCapabilitiesSupported(Capability.ConsumableMonitoring);
 
     return (
         <Container>
-            {consumables}
+            {supported ? <ConsumablesInternal/> : (
+                <Typography color="error">This robot does not support consumables.</Typography>
+            )}
         </Container>
     );
 };

--- a/frontend/src/robot/ManualControl.tsx
+++ b/frontend/src/robot/ManualControl.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import {
+    Box,
+    Button,
+    Collapse,
+    Container,
+    FormControlLabel,
+    Grid,
+    LinearProgress,
+    Stack,
+    Switch,
+    Typography,
+    styled,
+} from "@mui/material";
+import {
+    Capability,
+    ManualControlCommand,
+    useManualControlInteraction,
+    useManualControlPropertiesQuery,
+    useManualControlStateQuery
+} from "../api";
+import {useCapabilitiesSupported} from "../CapabilitiesProvider";
+import {FullHeightGrid} from "../components/FullHeightGrid";
+import {
+    ArrowDownward as ArrowDownwardIcon,
+    ArrowUpward as ArrowUpwardIcon,
+    RotateLeft as RotateLeftIcon,
+    RotateRight as RotateRightIcon,
+} from "@mui/icons-material";
+
+const SideButton = styled(Button)({
+    width: "30%",
+    height: "100%",
+});
+
+const CenterButton = styled(Button)({
+    width: "100%",
+});
+
+const ManualControlInternal: React.FunctionComponent = (): JSX.Element => {
+    const {
+        data: manualControlState,
+        isLoading: manualControlStateLoading,
+        isError: manualControlStateError,
+    } = useManualControlStateQuery();
+
+    const {
+        data: manualControlProperties,
+        isLoading: manualControlPropertiesLoading,
+        isError: manualControlPropertiesError,
+    } = useManualControlPropertiesQuery();
+
+    const {mutate: sendInteraction, isLoading: interacting} = useManualControlInteraction();
+
+    const loading = manualControlPropertiesLoading || manualControlStateLoading;
+
+    const controls = React.useMemo(() => {
+        if (manualControlPropertiesError || manualControlStateError || !manualControlProperties || !manualControlState) {
+            return (
+                <Typography color="error">Error loading manual controls</Typography>
+            );
+        }
+
+        const controlsEnabled = !loading && manualControlState.enabled && !interacting;
+        const forwardEnabled = controlsEnabled && manualControlProperties.supportedMovementCommands.includes("forward");
+        const backwardEnabled = controlsEnabled && manualControlProperties.supportedMovementCommands.includes("backward");
+        const rotateCwEnabled = controlsEnabled && manualControlProperties.supportedMovementCommands.includes("rotate_clockwise");
+        const rotateCcwEnabled = controlsEnabled && manualControlProperties.supportedMovementCommands.includes("rotate_counterclockwise");
+
+        const sendMoveCommand = (command: ManualControlCommand): void => {
+            sendInteraction({
+                action: "move",
+                movementCommand: command,
+            });
+        };
+
+        return (
+            <>
+                <FormControlLabel control={<Switch
+                    checked={manualControlState.enabled}
+                    disabled={loading || interacting}
+                    onChange={(e) => {
+                        sendInteraction({
+                            action: e.target.checked ? "enable" : "disable"
+                        });
+                    }}
+                />} label="Enable manual control"/>
+                <Box/>
+
+                <Stack direction="row" sx={{width: "100%", height: "30vh"}} justifyContent="center" alignItems="center">
+                    <SideButton variant="outlined" disabled={!rotateCwEnabled}
+                        onClick={() => {
+                            sendMoveCommand("rotate_clockwise");
+                        }}>
+                        <RotateRightIcon/>
+                    </SideButton>
+                    <Stack sx={{width: "40%", height: "100%", ml: 1, mr: 1}} justifyContent="space-between">
+                        <CenterButton sx={{height: "65%"}} variant="outlined" disabled={!forwardEnabled}
+                            onClick={() => {
+                                sendMoveCommand("forward");
+                            }}>
+                            <ArrowUpwardIcon/>
+                        </CenterButton>
+                        <CenterButton sx={{height: "30%"}} variant="outlined" disabled={!backwardEnabled}
+                            onClick={() => {
+                                sendMoveCommand("backward");
+                            }}>
+                            <ArrowDownwardIcon/>
+                        </CenterButton>
+                    </Stack>
+                    <SideButton variant="outlined" disabled={!rotateCcwEnabled}
+                        onClick={() => {
+                            sendMoveCommand("rotate_counterclockwise");
+                        }}>
+                        <RotateLeftIcon/>
+                    </SideButton>
+                </Stack>
+            </>
+        );
+
+    }, [
+        loading,
+        manualControlProperties,
+        manualControlPropertiesError,
+        manualControlState,
+        manualControlStateError,
+        sendInteraction,
+        interacting,
+    ]);
+
+    return React.useMemo(() => {
+        return (
+            <FullHeightGrid container direction="column">
+                <Grid item flexGrow={1}>
+                    <Container>
+                        <Box sx={{mt: 10}}>
+                            <Collapse in={loading}>
+                                <LinearProgress/>
+                            </Collapse>
+                            {controls}
+                        </Box>
+                    </Container>
+                </Grid>
+            </FullHeightGrid>
+        );
+    }, [loading, controls]);
+};
+
+const ManualControl = (): JSX.Element => {
+    const [supported] = useCapabilitiesSupported(Capability.ManualControl);
+
+    return (
+        <>
+            {supported ? <ManualControlInternal/> : (
+                <Typography color="error">This robot does not support the manual control.</Typography>
+            )}
+        </>
+    );
+};
+
+export default ManualControl;

--- a/frontend/src/robot/RobotRouter.tsx
+++ b/frontend/src/robot/RobotRouter.tsx
@@ -2,6 +2,7 @@ import {Route, Switch} from "react-router";
 import {useRouteMatch} from "react-router-dom";
 import Consumables from "./Consumables";
 import Capabilities from "./capabilities";
+import ManualControl from "./ManualControl";
 
 const RobotRouter = (): JSX.Element => {
     const {path} = useRouteMatch();
@@ -10,6 +11,9 @@ const RobotRouter = (): JSX.Element => {
         <Switch>
             <Route exact path={path + "/consumables"}>
                 <Consumables/>
+            </Route>
+            <Route exact path={path + "/manual_control"}>
+                <ManualControl/>
             </Route>
             <Route exact path={path + "/settings"}>
                 <Capabilities/>


### PR DESCRIPTION
## Manual control

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature

# Description (Type A)

The "enabled" state has to be tracked somewhere. Yes, tracking it as internal state in the capability implementation is not great, but there is no "get manual control state" command, at least on Roborock (and Dreame?).

![image](https://user-images.githubusercontent.com/8963459/135325591-8c8ec57d-8da8-44d0-a0d5-c291ea58fbaa.png)
