### PR TITLE
fix(ui): MQTT port is an integer

### DIFF
--- a/frontend/src/settings/interfaces/MQTT.tsx
+++ b/frontend/src/settings/interfaces/MQTT.tsx
@@ -158,7 +158,8 @@ const MQTT = (): JSX.Element => {
                     id={inputId}
                     value={value}
                     onChange={(e) => {
-                        modifyMQTTConfig(e.target.value, configPath);
+                        const newValue = additionalProps?.type === "number" ? parseInt(e.target.value) : e.target.value;
+                        modifyMQTTConfig(newValue, configPath);
                     }}
                     aria-describedby={helperId}
                     disabled={disabled}


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature

# Description (Type A)

The UI set the port number as a string.

![image](https://user-images.githubusercontent.com/8963459/137399165-9b135dc1-5125-4801-85e3-e73ed61e3fee.png)

![image](https://user-images.githubusercontent.com/8963459/137399207-1afb56db-01d0-4621-baa0-a81bf0f399cb.png)
