### PR TITLE
Discussion: PluginManager

### DIFF
--- a/backend/lib/Valetudo.js
+++ b/backend/lib/Valetudo.js
@@ -11,6 +11,7 @@ const ValetudoEventStore = require("./ValetudoEventStore");
 const Webserver = require("./webserver/WebServer");
 
 const NetworkAdvertisementManager = require("./NetworkAdvertisementManager");
+const PluginManager = require("./plugins/PluginManager");
 const Scheduler = require("./scheduler/Scheduler");
 const Updater = require("./updater/Updater");
 const ValetudoEventHandlerFactory = require("./valetudo_events/ValetudoEventHandlerFactory");
@@ -93,6 +94,11 @@ class Valetudo {
             robot: this.robot
         });
 
+        this.pluginManager = new PluginManager({
+            config: this.config,
+            robot: this.robot,
+            valetudoEventStore: this.valetudoEventStore
+        });
 
         //This might get refactored if there are more of these options
         if (this.config.get("debug") && typeof this.config.get("debug").systemStatInterval === "number") {
@@ -194,6 +200,7 @@ class Valetudo {
         // shuts down valetudo (reverse startup sequence):
         clearInterval(this.gcInterval);
 
+        this.pluginManager.shutdown();
         await this.networkAdvertisementManager.shutdown();
         await this.scheduler.shutdown();
         if (this.mqttClient) {

--- a/backend/lib/doc/Configuration.openapi.json
+++ b/backend/lib/doc/Configuration.openapi.json
@@ -74,6 +74,17 @@
           },
           "debug": {
             "type": "object"
+          },
+          "pluginManager": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean"
+              },
+              "plugins": {
+                "type": "array"
+              }
+            }
           }
         }
       },

--- a/backend/lib/plugins/PluginManager.js
+++ b/backend/lib/plugins/PluginManager.js
@@ -1,0 +1,75 @@
+const Logger = require("../Logger");
+
+const VALETUDO_PLUGIN_API_LEVEL = 1;
+
+class PluginManager {
+    /**
+     * @param {object} options
+     * @param {import("../Configuration")} options.config
+     * @param {import("../core/ValetudoRobot")} options.robot
+     * @param {import("../ValetudoEventStore")} options.valetudoEventStore
+     */
+    constructor(options) {
+        this.config = options.config;
+        this.robot = options.robot;
+        this.eventStore = options.valetudoEventStore;
+
+        this.pluginManagerConfig = this.config.get("pluginManager");
+        this.activePlugins = {};
+
+        this.loadPlugins();
+    }
+
+    loadPlugins() {
+        if (this.pluginManagerConfig.enabled !== true) {
+            return;
+        }
+
+        this.pluginManagerConfig.plugins.forEach(pluginConfig => {
+            this.loadPlugin(pluginConfig);
+        });
+    }
+
+    loadPlugin(pluginConfig) {
+        if (!(pluginConfig.id in this.activePlugins)) {
+            try {
+                const plugin = require(pluginConfig.file);
+                if ("valetudo_plugin_api_level" in plugin && plugin.valetudo_plugin_api_level !== VALETUDO_PLUGIN_API_LEVEL) {
+                    throw new Error("API level " + plugin.valetudo_plugin_api_level + " != " + VALETUDO_PLUGIN_API_LEVEL);
+                }
+                this.initPlugin(plugin);
+                this.activePlugins[pluginConfig.id] = plugin;
+            } catch (e) {
+                Logger.error("Could not load plugin " + pluginConfig.id, e);
+            }
+        }
+    }
+
+    initPlugin(plugin) {
+        if ("valetudo_plugin_init" in plugin) {
+            plugin.valetudo_plugin_init({
+                robot: this.robot,
+                config: this.config,
+                eventStore: this.eventStore,
+                logger: Logger,
+                paths: module.paths,
+            });
+        }
+    }
+
+    deinitPlugin(plugin) {
+        if ("valetudo_plugin_deinit" in plugin) {
+            plugin.valetudo_plugin_deinit();
+        }
+    }
+
+    shutdown() {
+        Object.entries(this.activePlugins).forEach(entry => {
+            const [key, value] = entry;
+            this.deinitPlugin(value);
+            delete this.activePlugins[key];
+        });
+    }
+}
+
+module.exports = PluginManager;

--- a/backend/lib/res/default_config.json
+++ b/backend/lib/res/default_config.json
@@ -82,5 +82,9 @@
             "type": "github",
             "implementationSpecificConfig": {}
         }
+    },
+    "pluginManager": {
+        "enabled": false,
+        "plugins": []
     }
 }


### PR DESCRIPTION
## Discussion: PluginManager

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [x] New core feature

# Description (Type B)

This should have been a "discussion" but talking about code is easier if it's actually working. **Do not merge!**

The very basic PluginManager enables running simple plugins for Valetudo. I could not get imports from Valetudo to work (like `require("./Logger")`). Importing from Valetudos dependencies works.

Things that need discussion:

- [ ] How to declare "public" API in Valetudo for Plugins? Plugins potentially break when stuff gets changed in Valetudo. Imo we should not make any guarantees, plugin developers are responsible for keeping up to date. Or we provide a separate stable API.
- [ ] UI integration - the Plugins could provide JS-Code (React Components) that could be displayed on a separate page in the new UI?

## Example Plugin

```javascript
let Logger = null;

function valetudo_plugin_init({logger, robot, paths}) {
  // Get import paths from Valetudo process to be able to 'require' Valetudo dependencies
  paths.forEach(p => {
    if (!module.paths.includes(p)) {
      module.paths.push(p);
    }
  });

  // Since we cannot require("../Logger"), pass it as a parameter
  Logger = logger;
  Logger.info("Plugin initialized");

  // Require from Valetudo bundled dependencies
  const {generateId} = require("zoo-ids");
  Logger.info("Zoo ID: " + generateId());

  // Register listener
  robot.onMapUpdated(() => {
    Logger.info("Map updated");
  })
}

function valetudo_plugin_deinit() {
  // Clean up plugin stuff
  Logger.info("Plugin deintialized");

  // TODO: Unsubscribe from onMapUpdated? Requires Valetudo API
}

module.exports = {
  valetudo_plugin_init,
  valetudo_plugin_deinit,
  valetudo_plugin_api_level: 1
}
```

This works on my Z10:
```
[2021-10-26T17:17:15.555Z] [INFO] Autodetected DreameZ10ProValetudoRobot
[2021-10-26T17:17:15.636Z] [INFO] Starting Valetudo 2021.11.0
[...]
[2021-10-26T17:17:15.642Z] [INFO] Robot: Dreame Z10 Pro (DreameZ10ProValetudoRobot)
[2021-10-26T17:17:15.643Z] [INFO] JS Runtime Version: v16.10.0
[2021-10-26T17:17:15.643Z] [INFO] Arch: arm64
[...]
[2021-10-26T17:17:24.899Z] [INFO] Plugin initialized
[2021-10-26T17:17:24.902Z] [INFO] Zoo ID: TanCriticalCaribou
[...]
[2021-10-26T17:17:35.594Z] [INFO] Cloud connected
[2021-10-26T17:17:39.089Z] [INFO] Map updated
^C[2021-10-26T17:17:46.809Z] [INFO] Valetudo shutdown in progress...
[2021-10-26T17:17:46.811Z] [INFO] Plugin deintialized
[...]
```

