### PR TITLE
Reword readme, replace deprecated align HTML attribute with CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,27 @@
-<div align="center">
-    <img src="https://github.com/Hypfer/Valetudo/blob/master/assets/logo/valetudo_logo_with_name.svg" width="800" alt="valetudo">
-    <p align="center"><h2>Free your vacuum from the cloud</h2></p>
+<div style="margin: auto; text-align: center; width: 800px">
+    <img src="https://github.com/Hypfer/Valetudo/blob/master/assets/logo/valetudo_logo_with_name.svg" width="800" alt="Valetudo logo">
+    <h2>Free your vacuum from the cloud</h2>
 </div>
 
-Valetudo is a cloud replacement for vacuum robots enabling local-only operation. It is not a custom firmware.
+Valetudo is a cloud replacement for vacuum robots that enables local-only operation. It is not a custom firmware.
 That means that it cannot change anything about how the robot operates.
 
-What it can do however is protect your data and enable you to connect your robot
-to your home automation system without having to detour through a vendor cloud, which,
-apart from the whole data problematic, might not be reachable due to your internet connection
+What it can do, however, is keep your data private and enable you to connect your robot
+to your home automation system without having to detour through a vendor cloud. Not having to leave your local network reduces latency, and means you don't have to depend on a third-party service that might not be reachable due to your internet connection
 being down or some servers in the datacenter being on fire.
 
-Not having to leave your local network of course also benefits the latency of commands, status reports etc.
+Valetudo aims to be proof that easy-to-use and reliable smart appliances are possible without any cloud and/or account requirements.
+Maybe at some point it might help convince vendors that there is another, non-cloud, way of doing things.
 
-Valetudo aims to be proof that easy to use and reliable smart appliances are possible without any cloud and/or account requirements.
-Maybe at some point it might help convince vendors that there is another way of doing things.
-
-By default, Valetudo provides control over your vacuum robot via a **responsive webinterface** that works on all of your devices.
+By default, Valetudo provides control over your vacuum robot via a **responsive web interface** that works on all of your devices.
 It can be used on phones, tablets as well as your desktop computer.
 
 
 Furthermore, there's a **REST-interface** documented with **Swagger UI** as well as **MQTT**.
-With support for both **Homie** and **Home Assistant Autodiscovery** for MQTT, you should be able to connect Valetudo to
-the open-source smarthome software of your choice.
+With support for both **Homie** and **Home Assistant autodiscovery** for MQTT, you should be able to connect Valetudo to
+the open-source smart home software of your choice.
 
-There's also [an android companion app](https://valetudo.cloud/pages/companion_apps/valetudo_companion.html) which helps
+There's also [an android companion app](https://valetudo.cloud/pages/companion_apps/valetudo_companion.html) that helps
 setting-up your newly-rooted vacuum.
 
 


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [x] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


# Description (Type A)

I see the main readme has been nicely updated recently. This PR replaces the deprecated HTML `align = center`attribute and rewords some of the text for improved (in my opinion) readability.

I am participating in #hacktoberfest, so I would appreciate if you could add the 'hacktoberfest-accepted' label (or add #hacktoberfest topic to your repo). Thanks!