### PR TITLE
Allow providing duration values as integers

### DIFF
--- a/backend/lib/doc/Configuration.openapi.json
+++ b/backend/lib/doc/Configuration.openapi.json
@@ -211,6 +211,7 @@
                 "required": [
                   "enabled",
                   "addICBINVMapProperty",
+                  "durationsAsInteger",
                   "cleanAttributesOnShutdown"
                 ],
                 "properties": {
@@ -220,6 +221,10 @@
                   "addICBINVMapProperty": {
                     "type": "boolean",
                     "description": "If true, adds Homie definitions for ICBINV's PNG map topic as that's not possible to add in ICBINV itself."
+                  },
+                  "durationsAsInteger": {
+                    "type": "boolean",
+                    "description": "Provide duration values as an integer (hack for openHAB)."
                   },
                   "cleanAttributesOnShutdown": {
                     "type": "boolean"

--- a/backend/lib/mqtt/capabilities/ConsumableMonitoringCapabilityMqttHandle.js
+++ b/backend/lib/mqtt/capabilities/ConsumableMonitoringCapabilityMqttHandle.js
@@ -91,13 +91,15 @@ class ConsumableMonitoringCapabilityMqttHandle extends CapabilityMqttHandle {
     async addNewConsumable(topicId, attr) {
         this.registeredConsumables.push(topicId);
 
+        const durationDataType = this.controller.currentConfig.interfaces.homie.durationsAsInteger ? DataType.INTEGER : DataType.DURATION;
+
         this.registerChild(
             new PropertyMqttHandle({
                 parent: this,
                 controller: this.controller,
                 topicName: topicId,
                 friendlyName: this.genConsumableFriendlyName(attr),
-                datatype: attr.remaining.unit === stateAttrs.ConsumableStateAttribute.UNITS.PERCENT ? DataType.INTEGER : DataType.DURATION,
+                datatype: attr.remaining.unit === stateAttrs.ConsumableStateAttribute.UNITS.PERCENT ? DataType.INTEGER : durationDataType,
                 unit: attr.remaining.unit === stateAttrs.ConsumableStateAttribute.UNITS.PERCENT ? Unit.PERCENT : undefined,
                 format: attr.remaining.unit === stateAttrs.ConsumableStateAttribute.UNITS.PERCENT ? "0:100" : undefined,
                 getter: async () => {

--- a/backend/lib/res/default_config.json
+++ b/backend/lib/res/default_config.json
@@ -46,6 +46,7 @@
             "homie": {
                 "enabled": true,
                 "addICBINVMapProperty": false,
+                "durationsAsInteger": false,
                 "cleanAttributesOnShutdown": false
             },
             "homeassistant": {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -225,6 +225,7 @@ export interface MQTTConfiguration {
         homie: {
             enabled: boolean;
             addICBINVMapProperty: boolean;
+            durationsAsInteger: boolean;
             cleanAttributesOnShutdown: boolean;
         };
         homeassistant: {

--- a/frontend/src/settings/connectivity/MQTT.tsx
+++ b/frontend/src/settings/connectivity/MQTT.tsx
@@ -280,6 +280,7 @@ const MQTT = (): JSX.Element => {
                         <FormLabel component="legend">Select the options for Homie integration</FormLabel>
                         <FormGroup>
                             {renderSwitch("Provide autodiscovery for \"I Can't Believe It's Not Valetudo\" map", ["interfaces", "homie", "addICBINVMapProperty"])}
+                            {renderSwitch("Provide duration values as integers (minutes)", ["interfaces", "homie", "durationsAsInteger"])}
                             {renderSwitch("Delete autodiscovery on shutdown", ["interfaces", "homie", "cleanAttributesOnShutdown"])}
                         </FormGroup>
                     </FormControl>

--- a/util/generate_mqtt_docs.js
+++ b/util/generate_mqtt_docs.js
@@ -644,6 +644,7 @@ class FakeMqttController extends MqttController {
                 "homie": {
                     "enabled": true,
                     "addICBINVMapProperty": true,
+                    "durationsAsInteger": false,
                     "cleanAttributesOnShutdown": false
                 },
                 "homeassistant": {


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature

# Description (Type A)

Since it looks like this [Bug](https://github.com/openhab/openhab-addons/issues/10839) in openHAB won't be fixed in the near future, this fix/"feature" allows publishing duration values of consumables as an integer instead of ISO 8601 durations. Looks like openHAB only ever worked with Viomi, as consumables are reported in percent there.

I'm also in favor of removing this workaround once the bug gets fixed in openHAB.