### PR TITLE
NTPClient.js workaround for Viomi

### DIFF
--- a/backend/lib/NTPClient.js
+++ b/backend/lib/NTPClient.js
@@ -67,6 +67,15 @@ class NTPClient {
             this.state = new States.ValetudoNTPClientSyncedState({
                 offset: currentNTPTime.getTime() - preSyncTime.getTime()
             });
+            
+            //Viomi Robots seem to magically change back the time if the time change is greater than 5 minutes.
+            //This will simple write the same time 3 additional times, the time will be offset by 9seconds.
+            if(this.state.offset >= 30000) {
+                Logger.info("NTP offset is greater than 5minutes, define time three additional times");
+                setTimeout(() => {this.setTime(currentNTPTime);},3000);
+                setTimeout(() => {this.setTime(currentNTPTime);},6000);
+                setTimeout(() => {this.setTime(currentNTPTime);},9000);
+            }
 
             Logger.debug("Next NTP sync in " + ntpConfig.interval + " ms");
 
@@ -136,7 +145,7 @@ class NTPClient {
             dateString += date.getSeconds().toString().padStart(2,0);
 
 
-            execSync("date -s \""+dateString+"\"");
+            execSync("date -u -s \""+dateString+"\"");
 
             Logger.info("Successfully set the robot time via NTP to", date);
         } else {


### PR DESCRIPTION
Viomi Robots seem to magically change back the time if the time change is greater than 5 minutes.
This will simply write the same time 3 additional times, the time will be offset by 9seconds.

Additionally the date command was adjusted to change the system clock with UTC, as NTP time is UTC the system timezone will not matter.

## Type of change

Type A:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


# Description

I added a stupid workaround when the time offset is greater than 5minutes it will simple set the time 3 additional times (to the same time).
Also I changed the `date -s "<formattedDate>"` to `date -u -s "<formattedDate>"` so the time will be set in UTC.
 
I´m pretty sure following issues should get fixed.
Fixes #1156 #1111 
