### PR TITLE
fix LinuxAlsaSpeakerVolumeControlCapability

### DIFF
--- a/backend/lib/robots/common/linuxCapabilities/LinuxAlsaSpeakerVolumeControlCapability.js
+++ b/backend/lib/robots/common/linuxCapabilities/LinuxAlsaSpeakerVolumeControlCapability.js
@@ -74,15 +74,15 @@ class LinuxAlsaSpeakerVolumeControlCapability extends SpeakerVolumeControlCapabi
         if (amixer.status !== 0) {
             throw new Error("Failed to retrieve volume level");
         }
-        
+
         //  ES2019 alternative to matchAll. Pattern passed in should not have global flag
         function matchAll(pattern,haystack){
-            var regex = new RegExp(pattern,"g")
-            var matches = [];            
-            var match_result = haystack.match(regex);            
+            var regex = new RegExp(pattern,"g");
+            var matches = [];
+            var match_result = haystack.match(regex);
             for (let index in match_result){
                 var item = match_result[index];
-                matches[index] = item.match(new RegExp(pattern)); 
+                matches[index] = item.match(new RegExp(pattern));
             }
             return matches;
         }

--- a/backend/lib/robots/common/linuxCapabilities/LinuxAlsaSpeakerVolumeControlCapability.js
+++ b/backend/lib/robots/common/linuxCapabilities/LinuxAlsaSpeakerVolumeControlCapability.js
@@ -74,11 +74,22 @@ class LinuxAlsaSpeakerVolumeControlCapability extends SpeakerVolumeControlCapabi
         if (amixer.status !== 0) {
             throw new Error("Failed to retrieve volume level");
         }
+        
+        //  ES2019 alternative to matchAll. Pattern passed in should not have global flag
+        function matchAll(pattern,haystack){
+            var regex = new RegExp(pattern,"g")
+            var matches = [];            
+            var match_result = haystack.match(regex);            
+            for (let index in match_result){
+                var item = match_result[index];
+                matches[index] = item.match(new RegExp(pattern)); 
+            }
+            return matches;
+        }
 
         let levelCount = 0;
-        // TODO: Find ES2019 alternative to matchAll
         // @ts-ignore
-        const volume = amixer.stdout.matchAll(volumeRegex)
+        const volume = matchAll(volumeRegex,amixer.stdout.toString())
             .map((match) => {
                 return parseInt(match[1]);
             })
@@ -89,9 +100,8 @@ class LinuxAlsaSpeakerVolumeControlCapability extends SpeakerVolumeControlCapabi
 
         let mute;
         if (muteSupported) {
-            // TODO: Find ES2019 alternative to matchAll
             // @ts-ignore
-            mute = amixer.stdout.matchAll(muteRegex)
+            mute = matchAll(muteRegex,amixer.stdout.toString())
                 .map((match) => {
                     return match[1] === "off";
                 })


### PR DESCRIPTION
Fix for TypeError: amixer.stdout.matchAll is not a function error

## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

1) amixer.stdout has buffer type and must be converted toString
https://stackoverflow.com/a/34909314
2) String.prototype.matchAll replaced with local function from
https://stackoverflow.com/a/63005798, because
after converting stdout to string matchAll throw a 
TypeError: String.prototype.matchAll called with a non-global RegExp argument
https://stackoverflow.com/a/60290199

Tested on viomi-v8. Now speaker control is working
 
<!-- Delete if there is none -->
Fixes #1062

