### PR TITLE
fix(ViomiPersistentMapControlCapability): fixed can’t enable persistent data

### DIFF
--- a/backend/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/backend/lib/robots/viomi/ViomiValetudoRobot.js
@@ -76,6 +76,10 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
             robot: this
         }));
 
+        this.registerCapability(new capabilities.ViomiCurrentStatisticsCapability({
+            robot: this
+        }));
+
         this.registerCapability(new capabilities.ViomiPersistentMapControlCapability({
             robot: this
         }));

--- a/backend/lib/robots/viomi/capabilities/ViomiPersistentMapControlCapability.js
+++ b/backend/lib/robots/viomi/capabilities/ViomiPersistentMapControlCapability.js
@@ -25,25 +25,26 @@ class ViomiPersistentMapControlCapability extends PersistentMapControlCapability
 
     /**
      * Wait for this.isEnabled()==targetState up to timeout seconds, returns true if target state was reached
+     *
      * @param {boolean} targetState
      * @param {number} timeout in seconds
      * @returns {Promise<boolean>}
      */
     async waitForState(targetState,timeout) {
         function sleep(ms) {
-          return new Promise((resolve) => {
-            setTimeout(resolve, ms);
-          });
+            return new Promise((resolve) => {
+                setTimeout(resolve, ms);
+            });
         }
 
         let startTime=Date.now();
-        do
-        {
+        do {
             let currentState=await this.isEnabled();
-            if(currentState==targetState)
+            if (currentState===targetState) {
                 return true;
+            }
             await sleep(100);
-        } while(Math.abs(startTime-Date.now())<(timeout*1000));
+        } while (Math.abs(startTime-Date.now())<(timeout*1000));
         return false;
     }
 

--- a/backend/lib/robots/viomi/capabilities/ViomiPersistentMapControlCapability.js
+++ b/backend/lib/robots/viomi/capabilities/ViomiPersistentMapControlCapability.js
@@ -24,11 +24,38 @@ class ViomiPersistentMapControlCapability extends PersistentMapControlCapability
     }
 
     /**
+     * Wait for this.isEnabled()==targetState up to timeout seconds, returns true if target state was reached
+     * @param {boolean} targetState
+     * @param {number} timeout in seconds
+     * @returns {Promise<boolean>}
+     */
+    async waitForState(targetState,timeout) {
+        function sleep(ms) {
+          return new Promise((resolve) => {
+            setTimeout(resolve, ms);
+          });
+        }
+
+        let startTime=Date.now();
+        do
+        {
+            let currentState=await this.isEnabled();
+            if(currentState==targetState)
+                return true;
+            await sleep(100);
+        } while(Math.abs(startTime-Date.now())<(timeout*1000));
+        return false;
+    }
+
+
+    /**
      * @returns {Promise<void>}
      */
     async enable() {
         // TODO: test
         await this.robot.sendCommand("set_remember", [1], {});
+        // wait for persistentMapState to change (up to 10 seconds)
+        await this.waitForState(true,10);
     }
 
     /**
@@ -37,6 +64,8 @@ class ViomiPersistentMapControlCapability extends PersistentMapControlCapability
     async disable() {
         // TODO: test
         await this.robot.sendCommand("set_remember", [0], {});
+        // wait for persistentMapState to change (up to 10 seconds)
+        await this.waitForState(false,10);
     }
 }
 


### PR DESCRIPTION

## Type of change

Type A:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

Fix for two problems with persistent data switch on Viomi:
1) add registerCapability ViomiCurrentStatisticsCapability. ViomiCurrentStatisticsCapability is used by assignment
https://github.com/Hypfer/Valetudo/blob/master/backend/lib/robots/viomi/ViomiValetudoRobot.js#L340
this.capabilities[capabilities.ViomiCurrentStatisticsCapability.TYPE].currentStatistics.area=...
which was causing an error.
2) add waitForState in enable/disable methods of ViomiPersistentMapControlCapability. Persistent data state doesn't change immediately (i observed 2-5 second delay), which causes gui to display incorrect switch state. With added delay enable/disable requests are delayed until state changes to desired value (or timeout 10s). Now gui works as expected.

Initially i assumed that not working switch was the reason why vacuum was resetting map on stop/home actions. It turns out that Viomi v8 only creates map once and does not expand or update it. So after "reset map" and complete floor cleanup it finally saved floor plan. Not sure if enabling persistent data has any effect. 
May be sequence of actions for creating/recreating map should be shown in gui to new users.

<!-- Delete if there is none -->
Fixes #1211
<!-- This link is required -->
Feature discussion thread:
