### PR TITLE
Add Roborock LED controls

### DIFF
--- a/backend/lib/core/capabilities/ButtonLightsControlCapability.js
+++ b/backend/lib/core/capabilities/ButtonLightsControlCapability.js
@@ -1,0 +1,15 @@
+const SimpleToggleCapability = require("./SimpleToggleCapability");
+
+/**
+ * @template {import("../ValetudoRobot")} T
+ * @extends SimpleToggleCapability<T>
+ */
+class ButtonLightsControlCapability extends SimpleToggleCapability {
+    getType() {
+        return ButtonLightsControlCapability.TYPE;
+    }
+}
+
+ButtonLightsControlCapability.TYPE = "ButtonLightsControlCapability";
+
+module.exports = ButtonLightsControlCapability;

--- a/backend/lib/core/capabilities/StatusLEDControlCapability.js
+++ b/backend/lib/core/capabilities/StatusLEDControlCapability.js
@@ -1,0 +1,15 @@
+const SimpleToggleCapability = require("./SimpleToggleCapability");
+
+/**
+ * @template {import("../ValetudoRobot")} T
+ * @extends SimpleToggleCapability<T>
+ */
+class StatusLEDControlCapability extends SimpleToggleCapability {
+    getType() {
+        return StatusLEDControlCapability.TYPE;
+    }
+}
+
+StatusLEDControlCapability.TYPE = "StatusLEDControlCapability";
+
+module.exports = StatusLEDControlCapability;

--- a/backend/lib/core/capabilities/index.js
+++ b/backend/lib/core/capabilities/index.js
@@ -2,6 +2,7 @@ module.exports = {
     AutoEmptyDockAutoEmptyControlCapability: require("./AutoEmptyDockAutoEmptyControlCapability"),
     AutoEmptyDockManualTriggerCapability: require("./AutoEmptyDockManualTriggerCapability"),
     BasicControlCapability: require("./BasicControlCapability"),
+    ButtonLightsControlCapability: require("./ButtonLightsControlCapability"),
     CarpetModeControlCapability: require("./CarpetModeControlCapability"),
     CombinedVirtualRestrictionsCapability: require("./CombinedVirtualRestrictionsCapability"),
     ConsumableMonitoringCapability: require("./ConsumableMonitoringCapability"),

--- a/backend/lib/core/capabilities/index.js
+++ b/backend/lib/core/capabilities/index.js
@@ -26,6 +26,7 @@ module.exports = {
     SensorCalibrationCapability: require("./SensorCalibrationCapability"),
     SpeakerTestCapability: require("./SpeakerTestCapability"),
     SpeakerVolumeControlCapability: require("./SpeakerVolumeControlCapability"),
+    StatusLEDControlCapability: require("./StatusLEDControlCapability"),
     TotalStatisticsCapability: require("./TotalStatisticsCapability"),
     VoicePackManagementCapability: require("./VoicePackManagementCapability"),
     WaterUsageControlCapability: require("./WaterUsageControlCapability"),

--- a/backend/lib/robots/roborock/RoborockS7ValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockS7ValetudoRobot.js
@@ -39,6 +39,8 @@ class RoborockS7ValetudoRobot extends RoborockGen4ValetudoRobot {
             type: entities.state.attributes.AttachmentStateAttribute.TYPE.MOP,
             attached: false
         }));
+
+        this.registerCapability(new capabilities.RoborockStatusLEDControlCapability({robot: this}));
     }
 
     getModelName() {

--- a/backend/lib/robots/roborock/RoborockValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockValetudoRobot.js
@@ -55,7 +55,6 @@ class RoborockValetudoRobot extends MiioValetudoRobot {
             capabilities.RoborockManualControlCapability,
             capabilities.RoborockTotalStatisticsCapability,
             capabilities.RoborockCurrentStatisticsCapability,
-            capabilities.RoborockStatusLEDControlCapability,
         ].forEach(capability => {
             this.registerCapability(new capability({robot: this}));
         });

--- a/backend/lib/robots/roborock/RoborockValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockValetudoRobot.js
@@ -53,7 +53,8 @@ class RoborockValetudoRobot extends MiioValetudoRobot {
             capabilities.RoborockVoicePackManagementCapability,
             capabilities.RoborockManualControlCapability,
             capabilities.RoborockTotalStatisticsCapability,
-            capabilities.RoborockCurrentStatisticsCapability
+            capabilities.RoborockCurrentStatisticsCapability,
+            capabilities.RoborockStatusLEDControlCapability,
         ].forEach(capability => {
             this.registerCapability(new capability({robot: this}));
         });

--- a/backend/lib/robots/roborock/RoborockValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockValetudoRobot.js
@@ -41,6 +41,7 @@ class RoborockValetudoRobot extends MiioValetudoRobot {
 
         [
             capabilities.RoborockBasicControlCapability,
+            capabilities.RoborockButtonLightsControlCapability,
             capabilities.RoborockConsumableMonitoringCapability,
             capabilities.RoborockZoneCleaningCapability,
             capabilities.RoborockGoToLocationCapability,

--- a/backend/lib/robots/roborock/capabilities/RoborockButtonLightsControlCapability.js
+++ b/backend/lib/robots/roborock/capabilities/RoborockButtonLightsControlCapability.js
@@ -1,0 +1,34 @@
+const ButtonLightsControlCapability = require("../../../core/capabilities/ButtonLightsControlCapability");
+
+/**
+ * @extends ButtonLightsControlCapability<import("../RoborockValetudoRobot")>
+ */
+class RoborockButtonLightsControlCapability extends ButtonLightsControlCapability {
+
+    /**
+     * This function polls the current key lock state
+     *
+     * @returns {Promise<boolean>}
+     */
+    async isEnabled() {
+        const res = await this.robot.sendCommand("get_led_status", [], {});
+
+        return res[0] === 1;
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async enable() {
+        await this.robot.sendCommand("set_led_status", [1], {});
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async disable() {
+        await this.robot.sendCommand("set_led_status", [0], {});
+    }
+}
+
+module.exports = RoborockButtonLightsControlCapability;

--- a/backend/lib/robots/roborock/capabilities/RoborockStatusLEDControlCapability.js
+++ b/backend/lib/robots/roborock/capabilities/RoborockStatusLEDControlCapability.js
@@ -1,0 +1,34 @@
+const StatusLEDControlCapability = require("../../../core/capabilities/StatusLEDControlCapability");
+
+/**
+ * @extends StatusLEDControlCapability<import("../RoborockValetudoRobot")>
+ */
+class RoborockStatusLEDControlCapability extends StatusLEDControlCapability {
+
+    /**
+     * This function polls the current key lock state
+     *
+     * @returns {Promise<boolean>}
+     */
+    async isEnabled() {
+        const res = await this.robot.sendCommand("get_flow_led_status", [], {});
+
+        return res.status === 1;
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async enable() {
+        await this.robot.sendCommand("set_flow_led_status", {status: 1}, {});
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async disable() {
+        await this.robot.sendCommand("set_flow_led_status", {status: 0}, {});
+    }
+}
+
+module.exports = RoborockStatusLEDControlCapability;

--- a/backend/lib/robots/roborock/capabilities/index.js
+++ b/backend/lib/robots/roborock/capabilities/index.js
@@ -19,6 +19,7 @@ module.exports = {
     RoborockPersistentMapControlCapability: require("./RoborockPersistentMapControlCapability"),
     RoborockSpeakerTestCapability: require("./RoborockSpeakerTestCapability"),
     RoborockSpeakerVolumeControlCapability: require("./RoborockSpeakerVolumeControlCapability"),
+    RoborockStatusLEDControlCapability: require("./RoborockStatusLEDControlCapability"),
     RoborockTotalStatisticsCapability: require("./RoborockTotalStatisticsCapability"),
     RoborockVoicePackManagementCapability: require("./RoborockVoicePackManagementCapability"),
     RoborockWaterUsageControlCapability: require("./RoborockWaterUsageControlCapability"),

--- a/backend/lib/robots/roborock/capabilities/index.js
+++ b/backend/lib/robots/roborock/capabilities/index.js
@@ -1,5 +1,6 @@
 module.exports = {
     RoborockBasicControlCapability: require("./RoborockBasicControlCapability"),
+    RoborockButtonLightsControlCapability: require("./RoborockButtonLightsControlCapability"),
     RoborockCarpetModeControlCapability: require("./RoborockCarpetModeControlCapability"),
     RoborockCombinedVirtualRestrictionsCapability: require("./RoborockCombinedVirtualRestrictionsCapability"),
     RoborockConsumableMonitoringCapability: require("./RoborockConsumableMonitoringCapability"),

--- a/backend/lib/webserver/CapabilitiesRouter.js
+++ b/backend/lib/webserver/CapabilitiesRouter.js
@@ -83,6 +83,7 @@ const CAPABILITY_TYPE_TO_ROUTER_MAPPING = {
     [capabilities.PendingMapChangeHandlingCapability.TYPE]: capabilityRouters.PendingMapChangeHandlingCapabilityRouter,
     [capabilities.MappingPassCapability.TYPE]: capabilityRouters.MappingPassCapabilityRouter,
     [capabilities.KeyLockCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,
+    [capabilities.StatusLEDControlCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,
     [capabilities.ObstacleAvoidanceControlCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,
     [capabilities.AutoEmptyDockAutoEmptyControlCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,
     [capabilities.AutoEmptyDockManualTriggerCapability.TYPE]: capabilityRouters.AutoEmptyDockManualTriggerCapabilityRouter,

--- a/backend/lib/webserver/CapabilitiesRouter.js
+++ b/backend/lib/webserver/CapabilitiesRouter.js
@@ -83,6 +83,7 @@ const CAPABILITY_TYPE_TO_ROUTER_MAPPING = {
     [capabilities.PendingMapChangeHandlingCapability.TYPE]: capabilityRouters.PendingMapChangeHandlingCapabilityRouter,
     [capabilities.MappingPassCapability.TYPE]: capabilityRouters.MappingPassCapabilityRouter,
     [capabilities.KeyLockCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,
+    [capabilities.ButtonLightsControlCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,
     [capabilities.StatusLEDControlCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,
     [capabilities.ObstacleAvoidanceControlCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,
     [capabilities.AutoEmptyDockAutoEmptyControlCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,

--- a/backend/lib/webserver/capabilityRouters/doc/SimpleToggleCapabilityRouter.openapi.json
+++ b/backend/lib/webserver/capabilityRouters/doc/SimpleToggleCapabilityRouter.openapi.json
@@ -230,6 +230,83 @@
       }
     }
   },
+  "/api/v2/robot/capabilities/StatusLEDControlCapability": {
+    "get": {
+      "tags": [
+        "StatusLEDControlCapability"
+      ],
+      "summary": "Get Status LED state",
+      "responses": {
+        "200": {
+          "description": "Ok",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "put": {
+      "tags": [
+        "StatusLEDControlCapability"
+      ],
+      "summary": "Activate/deactivate Status LED",
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "enum": [
+                    "enable",
+                    "disable"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "$ref": "#/components/responses/200"
+        },
+        "400": {
+          "$ref": "#/components/responses/400"
+        }
+      }
+    }
+  },
+  "/api/v2/robot/capabilities/StatusLEDControlCapability/properties": {
+    "get": {
+      "tags": [
+        "StatusLEDControlCapability"
+      ],
+      "summary": "Get various capability-related properties",
+      "responses": {
+        "200": {
+          "description": "Ok",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "/api/v2/robot/capabilities/ObstacleAvoidanceControlCapability": {
     "get": {
       "tags": [

--- a/backend/lib/webserver/capabilityRouters/doc/SimpleToggleCapabilityRouter.openapi.json
+++ b/backend/lib/webserver/capabilityRouters/doc/SimpleToggleCapabilityRouter.openapi.json
@@ -307,6 +307,83 @@
       }
     }
   },
+  "/api/v2/robot/capabilities/ButtonLightsControlCapability": {
+    "get": {
+      "tags": [
+        "ButtonLightsControlCapability"
+      ],
+      "summary": "Get button lights state",
+      "responses": {
+        "200": {
+          "description": "Ok",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "put": {
+      "tags": [
+        "ButtonLightsControlCapability"
+      ],
+      "summary": "Activate/deactivate button lights",
+      "requestBody": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "action": {
+                  "type": "string",
+                  "enum": [
+                    "enable",
+                    "disable"
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "responses": {
+        "200": {
+          "$ref": "#/components/responses/200"
+        },
+        "400": {
+          "$ref": "#/components/responses/400"
+        }
+      }
+    }
+  },
+  "/api/v2/robot/capabilities/ButtonLightsControlCapability/properties": {
+    "get": {
+      "tags": [
+        "ButtonLightsControlCapability"
+      ],
+      "summary": "Get various capability-related properties",
+      "responses": {
+        "200": {
+          "description": "Ok",
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
   "/api/v2/robot/capabilities/ObstacleAvoidanceControlCapability": {
     "get": {
       "tags": [

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -664,6 +664,18 @@ export const sendKeyLockEnable = async (enable: boolean): Promise<void> => {
     await sendToggleMutation(Capability.KeyLock, enable);
 };
 
+export const fetchStatusLEDState = async (): Promise<SimpleToggleState> => {
+    return valetudoAPI
+        .get<SimpleToggleState>(`/robot/capabilities/${Capability.StatusLEDControl}`)
+        .then(({ data }) => {
+            return data;
+        });
+};
+
+export const sendStatusLEDEnable = async (enable: boolean): Promise<void> => {
+    await sendToggleMutation(Capability.StatusLEDControl, enable);
+};
+
 export const fetchCarpetModeState = async (): Promise<SimpleToggleState> => {
     return valetudoAPI
         .get<SimpleToggleState>(`/robot/capabilities/${Capability.CarpetModeControl}`)

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -676,6 +676,18 @@ export const sendStatusLEDEnable = async (enable: boolean): Promise<void> => {
     await sendToggleMutation(Capability.StatusLEDControl, enable);
 };
 
+export const fetchButtonLightsState = async (): Promise<SimpleToggleState> => {
+    return valetudoAPI
+        .get<SimpleToggleState>(`/robot/capabilities/${Capability.ButtonLightsControl}`)
+        .then(({ data }) => {
+            return data;
+        });
+};
+
+export const sendButtonLightsEnable = async (enable: boolean): Promise<void> => {
+    await sendToggleMutation(Capability.ButtonLightsControl, enable);
+};
+
 export const fetchCarpetModeState = async (): Promise<SimpleToggleState> => {
     return valetudoAPI
         .get<SimpleToggleState>(`/robot/capabilities/${Capability.CarpetModeControl}`)

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -23,6 +23,7 @@ import {
     fetchHTTPBasicAuthConfiguration,
     fetchKeyLockState,
     fetchLatestGitHubRelease,
+    fetchStatusLEDState,
     fetchManualControlProperties,
     fetchManualControlState,
     fetchMap,
@@ -66,6 +67,7 @@ import {
     sendHTTPBasicAuthConfiguration,
     sendJoinSegmentsCommand,
     sendKeyLockEnable,
+    sendStatusLEDEnable,
     sendLocateCommand,
     sendManualControlInteraction,
     sendMapReset,
@@ -149,6 +151,7 @@ enum CacheKey {
     Timers = "timers",
     TimerProperties = "timer_properties",
     ValetudoEvents = "valetudo_events",
+    StatusLED = "status_led",
     Log = "log",
     LogLevel = "log_level",
     KeyLockInformation = "key_lock",
@@ -870,6 +873,22 @@ export const useKeyLockStateMutation = () => {
         CacheKey.KeyLockInformation,
         (enable: boolean) => {
             return sendKeyLockEnable(enable).then(fetchKeyLockState);
+        }
+    );
+};
+
+export const useStatusLEDStateQuery = () => {
+    return useQuery(CacheKey.StatusLED, fetchStatusLEDState, {
+        staleTime: Infinity
+    });
+};
+
+export const useStatusLEDStateMutation = () => {
+    return useValetudoFetchingMutation(
+        useOnCommandError(Capability.StatusLEDControl),
+        CacheKey.StatusLED,
+        (enable: boolean) => {
+            return sendStatusLEDEnable(enable).then(fetchStatusLEDState);
         }
     );
 };

--- a/frontend/src/api/hooks.ts
+++ b/frontend/src/api/hooks.ts
@@ -12,6 +12,7 @@ import {
     BasicControlCommand,
     deleteTimer,
     fetchAutoEmptyDockAutoEmptyControlState,
+    fetchButtonLightsState,
     fetchCapabilities,
     fetchCarpetModeState,
     fetchCombinedVirtualRestrictionsPropertiesProperties,
@@ -55,6 +56,7 @@ import {
     sendAutoEmptyDockAutoEmptyControlEnable,
     sendAutoEmptyDockManualTriggerCommand,
     sendBasicControlCommand,
+    sendButtonLightsEnable,
     sendCarpetModeEnable,
     sendCleanSegmentsCommand,
     sendCleanTemporaryZonesCommand,
@@ -152,6 +154,7 @@ enum CacheKey {
     TimerProperties = "timer_properties",
     ValetudoEvents = "valetudo_events",
     StatusLED = "status_led",
+    ButtonLights = "button_lights",
     Log = "log",
     LogLevel = "log_level",
     KeyLockInformation = "key_lock",
@@ -889,6 +892,22 @@ export const useStatusLEDStateMutation = () => {
         CacheKey.StatusLED,
         (enable: boolean) => {
             return sendStatusLEDEnable(enable).then(fetchStatusLEDState);
+        }
+    );
+};
+
+export const useButtonLightsStateQuery = () => {
+    return useQuery(CacheKey.ButtonLights, fetchButtonLightsState, {
+        staleTime: Infinity
+    });
+};
+
+export const useButtonLightsStateMutation = () => {
+    return useValetudoFetchingMutation(
+        useOnCommandError(Capability.ButtonLightsControl),
+        CacheKey.ButtonLights,
+        (enable: boolean) => {
+            return sendButtonLightsEnable(enable).then(fetchButtonLightsState);
         }
     );
 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -11,6 +11,7 @@ export enum Capability {
     FanSpeedControl = "FanSpeedControlCapability",
     GoToLocation = "GoToLocationCapability",
     KeyLock = "KeyLockCapability",
+    StatusLEDControl = "StatusLEDControlCapability",
     Locate = "LocateCapability",
     ManualControl = "ManualControlCapability",
     MapReset = "MapResetCapability",

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -2,6 +2,7 @@ export enum Capability {
     AutoEmptyDockAutoEmptyControl = "AutoEmptyDockAutoEmptyControlCapability",
     AutoEmptyDockManualTrigger = "AutoEmptyDockManualTriggerCapability",
     BasicControl = "BasicControlCapability",
+    ButtonLightsControl = "ButtonLightsControlCapability",
     CarpetModeControl = "CarpetModeControlCapability",
     CombinedVirtualRestrictions = "CombinedVirtualRestrictionsCapability",
     ConsumableMonitoring = "ConsumableMonitoringCapability",

--- a/frontend/src/robot/capabilities/Switches.tsx
+++ b/frontend/src/robot/capabilities/Switches.tsx
@@ -13,7 +13,9 @@ import {
     useObstacleAvoidanceModeStateMutation,
     useObstacleAvoidanceModeStateQuery,
     usePersistentDataMutation,
-    usePersistentDataQuery
+    usePersistentDataQuery,
+    useButtonLightsStateQuery,
+    useButtonLightsStateMutation
 } from "../../api";
 import ConfirmationDialog from "../../components/ConfirmationDialog";
 import {useCapabilitiesSupported} from "../../CapabilitiesProvider";
@@ -135,6 +137,22 @@ const StatusLEDControlSwitch = () => {
     );
 };
 
+const ButtonLightsControlSwitch = () => {
+    const {data, isFetching, isError} = useButtonLightsStateQuery();
+    const {mutate: onChange, isLoading: isChanging} = useButtonLightsStateMutation();
+    const loading = isFetching || isChanging;
+
+    return renderSwitch(
+        isError,
+        loading,
+        data?.enabled || false,
+        "Button lights",
+        "The light will go off 1 minute after the robot is fully charged. If the robot is already docked and fully charged, switching off this setting will take effect after 1 minute.",
+        onChange,
+        Capability.ButtonLightsControl
+    );
+};
+
 const CarpetModeSwitch = () => {
     const {data, isFetching, isError} = useCarpetModeStateQuery();
     const {mutate: onChange, isLoading: isChanging} = useCarpetModeStateMutation();
@@ -188,6 +206,7 @@ const Switches: FunctionComponent = () => {
         persistentMapControl,
         keyLockControl,
         ledControl,
+        ButtonLightsControl,
         carpetModeControl,
         obstacleAvoidanceControl,
         autoEmptyDockAutoEmptyControl
@@ -195,6 +214,7 @@ const Switches: FunctionComponent = () => {
         Capability.PersistentMapControl,
         Capability.KeyLock,
         Capability.StatusLEDControl,
+        Capability.ButtonLightsControl,
         Capability.CarpetModeControl,
         Capability.ObstacleAvoidanceControl,
         Capability.AutoEmptyDockAutoEmptyControl
@@ -205,6 +225,7 @@ const Switches: FunctionComponent = () => {
             {persistentMapControl && <PersistentDataSwitch/>}
             {keyLockControl && <KeyLockSwitch/>}
             {ledControl && <StatusLEDControlSwitch/>}
+            {ButtonLightsControl && <ButtonLightsControlSwitch/>}
             {carpetModeControl && <CarpetModeSwitch/>}
             {obstacleAvoidanceControl && <ObstacleAvoidanceSwitch/>}
             {autoEmptyDockAutoEmptyControl && <AutoEmptyDockAutoEmptySwitch/>}

--- a/frontend/src/robot/capabilities/Switches.tsx
+++ b/frontend/src/robot/capabilities/Switches.tsx
@@ -8,6 +8,8 @@ import {
     useCarpetModeStateQuery,
     useKeyLockStateMutation,
     useKeyLockStateQuery,
+    useStatusLEDStateMutation,
+    useStatusLEDStateQuery,
     useObstacleAvoidanceModeStateMutation,
     useObstacleAvoidanceModeStateQuery,
     usePersistentDataMutation,
@@ -117,6 +119,22 @@ const KeyLockSwitch = () => {
     );
 };
 
+const StatusLEDControlSwitch = () => {
+    const {data, isFetching, isError} = useStatusLEDStateQuery();
+    const {mutate: onChange, isLoading: isChanging} = useStatusLEDStateMutation();
+    const loading = isFetching || isChanging;
+
+    return renderSwitch(
+        isError,
+        loading,
+        data?.enabled || false,
+        "Status indicator light",
+        "",
+        onChange,
+        Capability.StatusLEDControl
+    );
+};
+
 const CarpetModeSwitch = () => {
     const {data, isFetching, isError} = useCarpetModeStateQuery();
     const {mutate: onChange, isLoading: isChanging} = useCarpetModeStateMutation();
@@ -169,12 +187,14 @@ const Switches: FunctionComponent = () => {
     const [
         persistentMapControl,
         keyLockControl,
+        ledControl,
         carpetModeControl,
         obstacleAvoidanceControl,
         autoEmptyDockAutoEmptyControl
     ] = useCapabilitiesSupported(
         Capability.PersistentMapControl,
         Capability.KeyLock,
+        Capability.StatusLEDControl,
         Capability.CarpetModeControl,
         Capability.ObstacleAvoidanceControl,
         Capability.AutoEmptyDockAutoEmptyControl
@@ -184,6 +204,7 @@ const Switches: FunctionComponent = () => {
         <CapabilityItem title={"Switches"}>
             {persistentMapControl && <PersistentDataSwitch/>}
             {keyLockControl && <KeyLockSwitch/>}
+            {ledControl && <StatusLEDControlSwitch/>}
             {carpetModeControl && <CarpetModeSwitch/>}
             {obstacleAvoidanceControl && <ObstacleAvoidanceSwitch/>}
             {autoEmptyDockAutoEmptyControl && <AutoEmptyDockAutoEmptySwitch/>}

--- a/util/build_openapi_schema.mjs
+++ b/util/build_openapi_schema.mjs
@@ -52,7 +52,8 @@ const options = {
             {name: "CombinedVirtualRestrictionsCapability", description: "Combined virtual restrictions capability"},
             {name: "PendingMapChangeHandlingCapability", description: "Pending map change handling capability"},
             {name: "MappingPassCapability", description: "Mapping pass capability"},
-            {name: "KeyLockCapability", description: "Key lock capability"}
+            {name: "KeyLockCapability", description: "Key lock capability"},
+            {name: "StatusLEDControlCapability", description: "Status LED control capability"}
         ],
         components: {
             responses: {


### PR DESCRIPTION
## Type of change
Type B:
- [X] New capability
- [ ] New core feature

# Description (Type B)
2 core capabilities are added:
- ButtonLightsControlCapability
- StatusLEDControlCapability

Implementations for both capabilities for Roborock are added.

ButtonLights should be supported on all Roborocks (or at least most of them). This capability allows you to enable/disable buttons backlight when robot is fully charged.
StatusLED AFAIK is specific to Roborock S7. I checked the pics and user manuals for most of the recent models, dedicated status LED doesn't seem to be present on them.

Feature discussion thread: https://github.com/Hypfer/Valetudo/issues/553
I started developing this feature when core capability was still present. But then I noticed it got removed recently (I'm assuming because there were no vendor-specific implementations). This implementation is differs from the old one in the sense that it doesn't support LED sub-types. Justification: these aren't the same core features, different commands are sent to the robot. So I'd say these are more like fan speed and water usage: concept is similar, but controlled entities are methods are different.
However, I could re-implement it with sub-types if you prefer it that way.

Note: the description for the button lights used in the UI is probably vendor-specific. It might be a good idea to have that message returned by robot implementation via API. I could return another `description: string` property in the response object along with the `enabled: bool`. What do you think?

