### PR TITLE
fix(vendor.roborock): Fix resetting incomplete map on Roborock. Detect and reset current map slot.

### DIFF
--- a/backend/lib/robots/roborock/RoborockValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockValetudoRobot.js
@@ -307,6 +307,10 @@ class RoborockValetudoRobot extends MiioValetudoRobot {
             }));
         }
 
+        if (data["map_status"] !== undefined) {
+            this.mapStatus = data["map_status"];
+        }
+
         this.emitStateAttributesUpdated();
     }
 

--- a/backend/lib/robots/roborock/capabilities/RoborockMultiMapMapResetCapability.js
+++ b/backend/lib/robots/roborock/capabilities/RoborockMultiMapMapResetCapability.js
@@ -8,7 +8,24 @@ class RoborockMultiMapMapResetCapability extends MapResetCapability {
      * @returns {Promise<void>}
      */
     async reset() {
-        let res = await this.robot.sendCommand("del_map", [0], {});
+        if (this.robot.mapStatus === MAP_STATUS.NO_MAP) {
+            throw new Error("Map doesn't exist. Nothing to reset.");
+        }
+        if (this.robot.mapStatus === MAP_STATUS.NEW_MAP) {
+            // saving the map takes a bit of time, usually up to 5 secs
+            let res = await this.robot.sendCommand("manual_segment_map", [{"map_flag":-1}], {timeout: 10000});
+            if (!(Array.isArray(res) && res[0] === 1)) {
+                throw new Error("Map is incomplete and not saved. Attempt to save map failed.");
+            }
+
+            await this.robot.pollState();
+        }
+
+        const multiMapId = MAP_STATUS_TO_MUTIMAP_ID[this.robot.mapStatus];
+        if (multiMapId === undefined) {
+            throw new Error("Unknown map status: " + this.robot.mapStatus + ". Unable to reset map.");
+        }
+        let res = await this.robot.sendCommand("del_map", [multiMapId], {});
 
         if (!(Array.isArray(res) && res[0] === "ok")) {
             throw new Error("Failed to reset map: " + res);
@@ -17,5 +34,21 @@ class RoborockMultiMapMapResetCapability extends MapResetCapability {
         this.robot.clearValetudoMap();
     }
 }
+
+const MAP_STATUS = Object.freeze({
+    NO_MAP: 252,
+    NEW_MAP: 253, // a full clean-up hasn't been completed yet, map is incomplete and not saved into a slot
+    MAP_0: 3,
+    MAP_1: 7,
+    MAP_2: 11,
+    MAP_3: 15,
+});
+
+const MAP_STATUS_TO_MUTIMAP_ID = Object.freeze({
+    [MAP_STATUS.MAP_0]: 0,
+    [MAP_STATUS.MAP_1]: 1,
+    [MAP_STATUS.MAP_2]: 2,
+    [MAP_STATUS.MAP_3]: 3,
+});
 
 module.exports = RoborockMultiMapMapResetCapability;


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
# Description (Type A)

This PR adds 2 fixes or rather improvements to RoborockMultiMapResetCapability.

1. Roborocks can't delete current map if it's incomplete. You either have to save it manually first, or complete a full clean-up which ends with an auto-saving of the map to the first available slot. Since Valetudo has no concept of multi-map management, there's no way to save it manually. This PR adds an implicit map saving when reset is attempted with an incomplete map.

2. Since Valetudo has no concept of multi-maps and performs actions against currently active map, it is reasonable to expect that it resets current map. Current map is not necessarily the one with id: 0. Even though Valetudo can't switch to a different map, user could do it through the official app or with other tools. So it's not entirely safe to assume current map id to be 0. This PR adds detection of currently used map slot to reset the correct map.
