### PR TITLE
fix(vendor.dreame): Take customOrder option into account for segment cleaning

### DIFF
--- a/backend/lib/robots/dreame/DreameGen2ValetudoRobot.js
+++ b/backend/lib/robots/dreame/DreameGen2ValetudoRobot.js
@@ -419,7 +419,7 @@ class DreameGen2ValetudoRobot extends DreameValetudoRobot {
             },
             segmentCleaningModeId: 18,
             iterationsSupported: 4,
-            customOrderSupported: false
+            customOrderSupported: true
         }));
 
         this.registerCapability(new capabilities.DreameMapSegmentEditCapability({

--- a/backend/lib/robots/dreame/capabilities/DreameMapSegmentationCapability.js
+++ b/backend/lib/robots/dreame/capabilities/DreameMapSegmentationCapability.js
@@ -67,7 +67,7 @@ class DreameMapSegmentationCapability extends MapSegmentationCapability {
                 typeof options?.iterations === "number" ? options.iterations : 1,
                 fanSpeed,
                 waterGrade,
-                options.customOrder ? i + 1 : 1 //determines the order in which the segments should be cleaned
+                options?.customOrder ? i + 1 : 1 //determines the order in which the segments should be cleaned
             ];
         });
 

--- a/backend/lib/robots/dreame/capabilities/DreameMapSegmentationCapability.js
+++ b/backend/lib/robots/dreame/capabilities/DreameMapSegmentationCapability.js
@@ -67,7 +67,7 @@ class DreameMapSegmentationCapability extends MapSegmentationCapability {
                 typeof options?.iterations === "number" ? options.iterations : 1,
                 fanSpeed,
                 waterGrade,
-                i + 1 //determines the order in which the segments should be cleaned
+                options.customOrder ? i + 1 : 1 //determines the order in which the segments should be cleaned
             ];
         });
 


### PR DESCRIPTION
## Type of change

Type A:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


# Description (Type A)

The `customOrderSupported` flag for Dreame robots currently reports `false` and the `DreameMapSegmentationCapability` ignores the `customOrder` option for segment cleaning.

It always passes an ascending order number along with the segments to clean, which effectively behaves like the roborock with customOrder = true.

This PR makes the dreame implementation behave exactly like the roborock one: when `customOrder` is `false` (or missing), the order number will be the same for all segments, which makes the robot determine the order. 

If `customOrder` is `true`, the old implentation is used and segments will be cleaned in order of appearance.

I'd consider this a bug fix, but of course it **will impact existing integrations, which omit the `customOrder`** but rely on it beeing cleaned in custom order.

Tested on Dreame L10 Pro Firmware 1105 

Related to #1147
