### PR TITLE
fix(vendor.viomi): Fix consumables and implement reset capability

### DIFF
--- a/backend/lib/robots/viomi/capabilities/ViomiConsumableMonitoringCapability.js
+++ b/backend/lib/robots/viomi/capabilities/ViomiConsumableMonitoringCapability.js
@@ -26,7 +26,7 @@ class ViomiConsumableMonitoringCapability extends ConsumableMonitoringCapability
                 type: ConsumableStateAttribute.TYPE.BRUSH,
                 subType: ConsumableStateAttribute.SUB_TYPE.MAIN,
                 remaining: {
-                    value: Math.round(Math.max(0, 360*60 - (rawConsumables.mainBrush / 60))),
+                    value: Math.round(Math.max(0, (360 - rawConsumables.mainBrush) * 60)),
                     unit: ConsumableStateAttribute.UNITS.MINUTES
                 }
             }),
@@ -34,7 +34,7 @@ class ViomiConsumableMonitoringCapability extends ConsumableMonitoringCapability
                 type: ConsumableStateAttribute.TYPE.BRUSH,
                 subType: ConsumableStateAttribute.SUB_TYPE.SIDE_RIGHT,
                 remaining: {
-                    value: Math.round(Math.max(0, 180*60 - (rawConsumables.sideBrush / 60))),
+                    value: Math.round(Math.max(0, (180 - rawConsumables.sideBrush) * 60)),
                     unit: ConsumableStateAttribute.UNITS.MINUTES
                 }
             }),
@@ -42,7 +42,7 @@ class ViomiConsumableMonitoringCapability extends ConsumableMonitoringCapability
                 type: ConsumableStateAttribute.TYPE.FILTER,
                 subType: ConsumableStateAttribute.SUB_TYPE.MAIN,
                 remaining: {
-                    value: Math.round(Math.max(0, 180*60 - (rawConsumables.filter / 60))),
+                    value: Math.round(Math.max(0, (180 - rawConsumables.filter) * 60)),
                     unit: ConsumableStateAttribute.UNITS.MINUTES
                 }
             }),
@@ -50,7 +50,7 @@ class ViomiConsumableMonitoringCapability extends ConsumableMonitoringCapability
                 type: ConsumableStateAttribute.TYPE.MOP,  // According to python-miio, unverified
                 subType: ConsumableStateAttribute.SUB_TYPE.MAIN,
                 remaining: {
-                    value: Math.round(Math.max(0, 180*60 - (rawConsumables.mop / 60))),
+                    value: Math.round(Math.max(0, (180 - rawConsumables.mop) * 60)),
                     unit: ConsumableStateAttribute.UNITS.MINUTES
                 }
             }),
@@ -72,7 +72,40 @@ class ViomiConsumableMonitoringCapability extends ConsumableMonitoringCapability
      * @returns {Promise<void>}
      */
     async resetConsumable(type, subType) {
-        throw new Error("Not implemented");
+        let idx;
+
+        switch (type) {
+            case ConsumableStateAttribute.TYPE.BRUSH:
+                switch (subType) {
+                    case ConsumableStateAttribute.SUB_TYPE.MAIN:
+                        idx = 1;
+                        break;
+                    case ConsumableStateAttribute.SUB_TYPE.SIDE_RIGHT:
+                        idx = 2;
+                        break;
+                }
+                break;
+            case ConsumableStateAttribute.TYPE.FILTER:
+                switch (subType) {
+                    case ConsumableStateAttribute.SUB_TYPE.MAIN:
+                        idx = 3;
+                        break;
+                }
+                break;
+            case ConsumableStateAttribute.TYPE.MOP:
+                switch (subType) {
+                    case ConsumableStateAttribute.SUB_TYPE.MAIN:
+                        idx = 4;
+                        break;
+                }
+                break;
+        }
+
+        if (idx) {
+            await this.robot.sendCommand("set_consumables", [idx, 0], {});
+        } else {
+            throw new Error("No such consumable");
+        }
     }
 
     getProperties() {


### PR DESCRIPTION
## Type of change

Type A:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [X] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


# Description (Type A)

* Values from get_consumables are in hours, not seconds
* Implement reset by calling set_consumables: at least 2 parameters are expected, first one in consumable index but the others are unknown, so a 0 is passed

Fixes  #1061


Feature discussion thread: https://github.com/Hypfer/Valetudo/discussions/1347
