### PR TITLE
chore: Only run the nightly job for the main repository

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -14,6 +14,7 @@
       'nightly_build':
         {
           'runs-on': 'ubuntu-latest',
+          'if': 'github.repository_owner == "Hypfer"',
           'steps':
             [
               { 'uses': 'actions/checkout@v2' },


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [x] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation

# Description (Type A)

The nightly job will be automatically run for all forks at the moment, failing
each night because a release can (obviously) not be published.