### PR TITLE
fix(vendor.roborock): Multiple fixes for Mijia 1S

### DIFF
--- a/backend/lib/robots/roborock/RoborockM1SValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockM1SValetudoRobot.js
@@ -57,11 +57,11 @@ RoborockM1SValetudoRobot.DEVICE_CONF_PATH = "/mnt/default/device.conf";
 RoborockM1SValetudoRobot.TOKEN_FILE_PATH = "/data/miio/device.token";
 
 const FAN_SPEEDS = {
-    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.MIN]: 1,
-    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.LOW]: 38,
-    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.MEDIUM]: 60,
-    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.HIGH]: 75,
-    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.MAX]: 100
+    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.LOW]: 101,
+    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.MEDIUM]: 102,
+    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.HIGH]: 103,
+    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.MAX]: 104,
+    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.OFF] : 105 //also known as mop mode
 };
 
 module.exports = RoborockM1SValetudoRobot;

--- a/backend/lib/robots/roborock/RoborockM1SValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockM1SValetudoRobot.js
@@ -26,7 +26,7 @@ class RoborockM1SValetudoRobot extends RoborockValetudoRobot {
         this.registerCapability(new capabilities.RoborockMapResetCapability({
             robot: this
         }));
-        this.registerCapability(new capabilities.RoborockMapSegmentationCapability({
+        this.registerCapability(new capabilities.RoborockMapSegmentSimpleCapability({
             robot: this
         }));
         this.registerCapability(new capabilities.RoborockMapSegmentEditCapability({

--- a/backend/lib/robots/roborock/RoborockM1SValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockM1SValetudoRobot.js
@@ -37,6 +37,10 @@ class RoborockM1SValetudoRobot extends RoborockValetudoRobot {
         }));
     }
 
+    setEmbeddedParameters() {
+        this.deviceConfPath = RoborockM1SValetudoRobot.DEVICE_CONF_PATH;
+        this.tokenFilePath = RoborockM1SValetudoRobot.TOKEN_FILE_PATH;
+    }
 
     getModelName() {
         return "M1S";
@@ -48,6 +52,9 @@ class RoborockM1SValetudoRobot extends RoborockValetudoRobot {
         return !!(deviceConf && deviceConf.model === "roborock.vacuum.m1s");
     }
 }
+
+RoborockM1SValetudoRobot.DEVICE_CONF_PATH = "/mnt/default/device.conf";
+RoborockM1SValetudoRobot.TOKEN_FILE_PATH = "/data/miio/device.token";
 
 const FAN_SPEEDS = {
     [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.MIN]: 1,

--- a/backend/lib/robots/roborock/capabilities/RoborockMapSegmentSimpleCapability.js
+++ b/backend/lib/robots/roborock/capabilities/RoborockMapSegmentSimpleCapability.js
@@ -1,0 +1,39 @@
+const MapSegmentationCapability = require("../../../core/capabilities/MapSegmentationCapability");
+
+/**
+ * @extends MapSegmentationCapability<import("../RoborockValetudoRobot")>
+ */
+class RoborockMapSegmentSimpleCapability extends MapSegmentationCapability {
+    /**
+     * Could be phrased as "cleanSegments" for vacuums or "mowSegments" for lawnmowers
+     *
+     *
+     * @param {Array<import("../../../entities/core/ValetudoMapSegment")>} segments
+     * @param {object} [options]
+     * @param {number} [options.iterations]
+     * @param {boolean} [options.customOrder]
+     * @returns {Promise<void>}
+     */
+    async executeSegmentAction(segments, options) {
+        const segmentIds = segments.map(segment => {
+            return parseInt(segment.id);
+        });
+
+        await this.robot.sendCommand("app_segment_clean", segmentIds, {});
+    }
+
+    /**
+     * @returns {import("../../../core/capabilities/MapSegmentationCapability").MapSegmentationCapabilityProperties}
+     */
+    getProperties() {
+        return {
+            iterationCount: {
+                min: 1,
+                max: 1
+            },
+            customOrderSupport: false
+        };
+    }
+}
+
+module.exports = RoborockMapSegmentSimpleCapability;

--- a/backend/lib/robots/roborock/capabilities/index.js
+++ b/backend/lib/robots/roborock/capabilities/index.js
@@ -13,6 +13,7 @@ module.exports = {
     RoborockMapResetCapability: require("./RoborockMapResetCapability"),
     RoborockMapSegmentEditCapability: require("./RoborockMapSegmentEditCapability"),
     RoborockMapSegmentRenameCapability: require("./RoborockMapSegmentRenameCapability"),
+    RoborockMapSegmentSimpleCapability: require("./RoborockMapSegmentSimpleCapability"),
     RoborockMapSegmentationCapability: require("./RoborockMapSegmentationCapability"),
     RoborockMapSnapshotCapability: require("./RoborockMapSnapshotCapability"),
     RoborockMultiMapMapResetCapability: require("./RoborockMultiMapMapResetCapability"),


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

1) Mijia 1S uses an old `app_segment_clean` method which does not support `repeat` and `clean_order_mode` options - just a list of segments
 
2) Fixed path to `device.token` for Mijia 1S

3) Fixed volume levels for Mijia 1S