### PR TITLE
fix(miio): process _async.stat, _otc.ncstat and _otc.ncinfo messages

### DIFF
--- a/backend/lib/miio/Dummycloud.js
+++ b/backend/lib/miio/Dummycloud.js
@@ -60,6 +60,14 @@ class Dummycloud {
                     }
                 });
                 return;
+            case "_async.stat":
+            case "_otc.ncinfo":
+            case "_otc.ncstat":
+                this.miioSocket.sendMessage({
+                    "id": msg.id,
+                    "result": "ok"
+                });
+                return;
         }
 
         if (!this.onIncomingCloudMessage(msg)) {


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
# Description (Type A)

Found some unhandled by dummycloud miio messages `_async.stat`, `_otc.ncstat` and `_otc.ncinfo`. All of them just spam the log every 30 min. "Real" cloud replied {"result":"ok"} according to traffic dump