### PR TITLE
fix(vendor.roborock): copy metadata from previous state on state update

### DIFF
--- a/backend/lib/robots/roborock/RoborockValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockValetudoRobot.js
@@ -210,7 +210,24 @@ class RoborockValetudoRobot extends MiioValetudoRobot {
             ) {
                 statusFlag = stateAttrs.StatusStateAttribute.FLAG.RESUMABLE;
 
-                if (data["in_cleaning"] === 2) {
+                if (data["in_cleaning"] === undefined) {
+                    const previousState = this.state.getFirstMatchingAttributeByConstructor(stateAttrs.StatusStateAttribute);
+
+                    // keep mataData from previous state
+                    if (previousState &&
+                        (
+                            previousState.value === stateAttrs.StatusStateAttribute.VALUE.PAUSED ||
+                            previousState.value === stateAttrs.StatusStateAttribute.VALUE.RETURNING ||
+                            previousState.value === stateAttrs.StatusStateAttribute.VALUE.DOCKED
+                        )
+                    ) {
+                        if (previousState.metaData.zoned === true) {
+                            statusMetaData.zoned = true;
+                        } else if (previousState.metaData.segment_cleaning === true) {
+                            statusMetaData.segment_cleaning = true;
+                        }
+                    }
+                } else if (data["in_cleaning"] === 2) {
                     //Since this is some roborock-related weirdness, we're using the metaData to store this
                     statusMetaData.zoned = true;
                 } else if (data["in_cleaning"] === 3) {


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
# Description (Type A)

`onIncomingCloudMessage()` method in RoborockValetudoRobot.js process both `props` and `event.status` messages using the same method `parseAndUpdateState()`. Since `props` message has a `status` field but missing `in_cleaning` field:
```
{
  "state": 10,
  "battery": 100,
  "fan_power": 105
}
```
status metadata lost if `props` message arrives right after `event.status` message, even if the actual state was not changed