### PR TITLE
Refactor RoborockValetudoRobot.pollMap() and track map nonce in mqtt

### DIFF
--- a/backend/lib/mqtt/handles/MapNodeMqttHandle.js
+++ b/backend/lib/mqtt/handles/MapNodeMqttHandle.js
@@ -28,6 +28,7 @@ class MapNodeMqttHandle extends NodeMqttHandle {
         }));
 
         this.robot = options.robot;
+        this.previousMapNonce = null;
 
         this.registerChild(
             new PropertyMqttHandle({
@@ -175,6 +176,12 @@ class MapNodeMqttHandle extends NodeMqttHandle {
         }
         const robot = this.robot;
 
+        if (this.previousMapNonce !== robot.state.map.metaData.nonce) {
+            this.previousMapNonce = robot.state.map.metaData.nonce;
+        } else {
+            return null;
+        }
+
         const promise = new Promise((resolve, reject) => {
             zlib.deflate(JSON.stringify(robot.state.map), (err, buf) => {
                 if (err !== null) {
@@ -217,6 +224,7 @@ class MapNodeMqttHandle extends NodeMqttHandle {
         } catch (err) {
             Logger.error("Error while deflating map data for mqtt publish", err);
         }
+        this.previousMapNonce = null;
         return null;
     }
 

--- a/backend/lib/robots/MiioValetudoRobot.js
+++ b/backend/lib/robots/MiioValetudoRobot.js
@@ -71,7 +71,8 @@ class MiioValetudoRobot extends ValetudoRobot {
         this.fdsUploadInProgress = false;
         this.mapPollingIntervals = {
             default: 60,
-            active: this.config.get("embedded") === true && Tools.IS_LOWMEM_HOST() ? 4 : 2
+            active: this.config.get("embedded") === true && Tools.IS_LOWMEM_HOST() ? 4 : 2,
+            error: 30
         };
         this.expressApp = express();
 


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [x] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation

# Description (Type A)

1. Roborock pollMap() method starts new map refresh loop every time its called -
dummycloud re-connected or robot send ```event.status``` message while in active state.
It causes map refresh loop run at maximum rate (600 msec delay) after cleaning cycle.
```
MiioValetudoRobot.js:

onCloudConnected() {
    Logger.info("Dummycloud connected");
    // start polling the map after a brief delay of 3.5s
    setTimeout(() => {
        return this.pollMap();
    }, 3500);
}
```
```
RoborockValetudoRobot.js:

onIncomingCloudMessage(msg) {
    switch (msg.method) {
        ...
        case "event.status":
            ...
            if (StatusStateAttribute && StatusStateAttribute.isActiveState) {
                this.pollMap();
            }
    ...
}

pollMap() {
   ...
   if (now.getTime() - 600 > this.lastMapPoll.getTime()) {
   ...
       this.sendCloud({"method": "get_map_v1"}).then(res => {
           if (res?.length === 1) {
                ...
                setTimeout(() => {
                    return this.pollMap();
                }, repollSeconds * 1000);
           }
   ...
}
```

2. Mqtt publish new map ~ 3 times after map poll,
nonce tracking in MapNodeMqttHandle.js prevents this.