### PR TITLE
fix(vendor.roborock): copy statusFlag from previous state on state update

### DIFF
--- a/backend/lib/robots/roborock/RoborockValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockValetudoRobot.js
@@ -213,7 +213,7 @@ class RoborockValetudoRobot extends MiioValetudoRobot {
                 if (data["in_cleaning"] === undefined) {
                     const previousState = this.state.getFirstMatchingAttributeByConstructor(stateAttrs.StatusStateAttribute);
 
-                    // keep mataData from previous state
+                    // keep statusFlag and metaData from previous state
                     if (previousState &&
                         (
                             previousState.value === stateAttrs.StatusStateAttribute.VALUE.PAUSED ||
@@ -221,6 +221,8 @@ class RoborockValetudoRobot extends MiioValetudoRobot {
                             previousState.value === stateAttrs.StatusStateAttribute.VALUE.DOCKED
                         )
                     ) {
+                        statusFlag = previousState.flag;
+
                         if (previousState.metaData.zoned === true) {
                             statusMetaData.zoned = true;
                         } else if (previousState.metaData.segment_cleaning === true) {


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
# Description (Type A)

Keep statusFlag for `props` message too. See: https://github.com/Hypfer/Valetudo/pull/1489
