### PR TITLE
fix(miiorobot): Fix ERR_HTTP_HEADERS_SENT exception

### DIFF
--- a/backend/lib/robots/MiioValetudoRobot.js
+++ b/backend/lib/robots/MiioValetudoRobot.js
@@ -287,6 +287,7 @@ class MiioValetudoRobot extends ValetudoRobot {
             // ott.io.mi.com asks for TCP hosts, which our dummycloud doesn’t (yet) support.
             if (req.query["dm"] === "ott.io.mi.com") {
                 res.status(501).send("miio/tcp not implemented");
+                return;
             }
             const info = {
                 "host_list": [


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation

# Description (Type A)

Fix unhandled exception on miio_client start/restart
```
[2022-05-12T21:31:35.232Z] [ERROR] Unhandled WebServer Error Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at new NodeError (node:internal/errors:377:5)
    at ServerResponse.setHeader (node:_http_outgoing:576:11)
    at ServerResponse.header (/snapshot/Valetudo/node_modules/express/lib/response.js:776:10)
    at ServerResponse.send (/snapshot/Valetudo/node_modules/express/lib/response.js:170:12)
    at ServerResponse.json (/snapshot/Valetudo/node_modules/express/lib/response.js:267:15)
    at ServerResponse.send (/snapshot/Valetudo/node_modules/express/lib/response.js:158:21)
    at /snapshot/Valetudo/backend/lib/robots/MiioValetudoRobot.js:304:29
    at Layer.handle [as handle_request] (/snapshot/Valetudo/node_modules/express/lib/router/layer.js:95:5)
    at next (/snapshot/Valetudo/node_modules/express/lib/router/route.js:137:13)
    at Route.dispatch (/snapshot/Valetudo/node_modules/express/lib/router/route.js:112:3) {
  code: 'ERR_HTTP_HEADERS_SENT'
}
```