### PR TITLE
docs: backup firmware encryption keys

### DIFF
--- a/docs/_pages/general/rooting-instructions.md
+++ b/docs/_pages/general/rooting-instructions.md
@@ -148,7 +148,7 @@ which at this point should be connected to the robots Wi-Fi AP.
 To do that, head back to the UART shell and create a tar file of all the required files like so: 
 
 ```
-tar cvf /tmp/backup.tar /mnt/private/ /mnt/misc/
+tar cvf /tmp/backup.tar /mnt/private/ /mnt/misc/ /etc/OTA_Key_pub.pem /etc/publickey.pem
 ```
 
 Then, look at the output of the `valetudo-helper-httpbridge` instance you've started previously.


### PR DESCRIPTION
Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [x] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
# Description (Type A)
I think it make sense to add the firmware encryption keys to backup.tar as mentioned here - https://github.com/dgiese/dustbuilder-howto/blob/master/dreameadapter/cmds.txt#L53