### PR TITLE
add documentation about http shortcuts

### DIFF
--- a/docs/_pages/companion_apps/http_shortcuts.md
+++ b/docs/_pages/companion_apps/http_shortcuts.md
@@ -1,0 +1,11 @@
+---
+title: HTTP Shortcuts (Android)
+category: Companion Apps
+order: 21
+---
+# HTTP Shortcuts
+
+If you don't have any home automation software but still want to add some comfort, you can install [HTTP Shortcuts](https://http-shortcuts.rmy.ch/) (also available on F-Droid), an app to issue arbitrary HTTP request.
+You can create shortcuts for any action, such as starting and stopping your roboto.
+But also you can start the cleaning of a segment or a predefined zone.
+HTTP Shortcuts provides an URI for each action, which can be triggered via NFC stickers.

--- a/docs/_pages/companion_apps/other_noteworthy_projects.md
+++ b/docs/_pages/companion_apps/other_noteworthy_projects.md
@@ -1,7 +1,7 @@
 ---
 title: Other Noteworthy Projects
 category: Companion Apps
-order: 21
+order: 22
 ---
 # Other Noteworthy Projects
 


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [x] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


# Description (Type A)

I added some short documentation about the open source app "HTTP Shortcut" (available on F-Droid and the play store). This app allows to issue arbitrary HTTP requests. For each request you create a shortcut. It allows scripting and state management (i.e. one can create variables shared between all shortcuts). Shortcuts can be triggered via app, "quick settings tile" or via activating an URI (so you can for example call it from a task automation app or via NFC stickers).

I am not affiliated with HTTP Shortcuts but I found it a very nice app. Valetudo and HTTP Shortcut are a perfect combination when you don't have any home automation but would like to have more "comfort"/"automation".