### PR TITLE
Clean segments by name.

### DIFF
--- a/backend/lib/mqtt/capabilities/MapSegmentationCapabilityMqttHandle.js
+++ b/backend/lib/mqtt/capabilities/MapSegmentationCapabilityMqttHandle.js
@@ -51,6 +51,29 @@ class MapSegmentationCapabilityMqttHandle extends CapabilityMqttHandle {
                     }
 
                     await this.capability.executeSegmentAction(segments, requestOptions);
+                } else if (Array.isArray(reqSegments.segment_names) && reqSegments.segment_names.length > 0){
+                    const requestOptions = {};
+
+                    if (typeof reqSegments.iterations === "number") {
+                        requestOptions.iterations = reqSegments.iterations;
+                    }
+
+                    if (reqSegments.customOrder === true) {
+                        requestOptions.customOrder = true;
+                    }
+
+                    const robotSegments = await this.capability.getSegments();
+                    const segments = [];
+
+                    for (const name of reqSegments.segment_names) {
+                        const segment = robotSegments.find(segm => {
+                            return (segm.name === name)
+                        });
+                        if (!segment) {
+                            throw new Error(`Segment Name does not exist, or map was not loaded: ${name}`);
+                        }
+                        segments.push(segment);
+                    }
                 } else {
                     throw new Error("Missing or empty segment_ids Array in payload");
                 }
@@ -68,6 +91,18 @@ class MapSegmentationCapabilityMqttHandle extends CapabilityMqttHandle {
                     iterations: 2,
                     customOrder: true
                 }, null, 2) +
+                "\n```" + 
+                "\n\n Also possible:\n\n" +
+                "```json\n" +
+                JSON.stringify({
+                    segment_names: [
+                        "Kitchen",
+                        "Livingroom",
+                        "Bathroom"
+                    ],
+                    iterations: 1,
+                    customOrder: false
+                }, null, 2) + 
                 "\n```"
         }));
     }


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [X] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

Over time, some segment borders blur into each other and I have to slice and combine those segments for crisp room separation. When I do this, the segment name gets deleted and the IDs change. I can rename the segment without a problem, but the IDs get messed up and my MQTT broker needs them. It would be nice to send commands by room name instead of room ID.
