### PR TITLE
docs: add group include, clear up customize include

### DIFF
--- a/docs/_pages/integrations/home-assistant-integration.md
+++ b/docs/_pages/integrations/home-assistant-integration.md
@@ -159,11 +159,12 @@ input_boolean.vacuum_study:
 ```
 
 Make sure to add
-```
+```yaml
+group: !include groups.yaml
 homeassistant:
   customize: !include customize.yaml
 ```
-into configuration.yaml
+into configuration.yaml. If you already have customizations, you can just copy them over into the the `/config/customize.yaml` file and replace the customize key.
 
 `/config/groups.yaml`
 ```yaml


### PR DESCRIPTION
## Type of change

- [x] Docs

The `groups.yaml` file doesn't seem to be imported by default and I was a bit confused why the card always said, that it could not find the group. Also, I had my own customizations already in place and needed to copy them over. This hopefully makes it clearer for other people. Additionally, this adds Syntax Highlighting on that one code block. Wdyt 👀 ?