### PR TITLE
Add implementations for Roborock S7 auto empty dock

### DIFF
--- a/backend/lib/robots/roborock/RoborockQuirkFactory.js
+++ b/backend/lib/robots/roborock/RoborockQuirkFactory.js
@@ -14,6 +14,57 @@ class RoborockQuirkFactory {
      */
     getQuirk(id) {
         switch (id) {
+            case RoborockQuirkFactory.KNOWN_QUIRKS.AUTO_EMPTY_LENGTH:
+                return new Quirk({
+                    id: id,
+                    title: "Auto Empty Duration",
+                    description: "Set the dustbin emptying duration when triggered by robot after docking.",
+                    options: ["Smart", "Quick", "Daily", "Max"],
+                    getter: async() => {
+                        const res = await this.robot.sendCommand("get_dust_collection_mode", [], {});
+
+                        if (!(res && res.mode !== undefined)) {
+                            throw new Error(`Received invalid response: ${res}`);
+                        } else {
+                            switch (res.mode) {
+                                case 4:
+                                    return "Max";
+                                case 2:
+                                    return "Daily";
+                                case 1:
+                                    return "Quick";
+                                case 0:
+                                    return "Smart";
+                                default:
+                                    throw new Error(`Received invalid value ${res.status}`);
+                            }
+                        }
+
+
+                    },
+                    setter: async(value) => {
+                        let val;
+
+                        switch (value) {
+                            case "Max":
+                                val = 4;
+                                break;
+                            case "Daily":
+                                val = 2;
+                                break;
+                            case "Quick":
+                                val = 1;
+                                break;
+                            case "Smart":
+                                val = 0;
+                                break;
+                            default:
+                                throw new Error(`Received invalid value ${value}`);
+                        }
+
+                        return this.robot.sendCommand("set_dust_collection_mode", { "mode": val }, {});
+                    }
+                });
             case RoborockQuirkFactory.KNOWN_QUIRKS.BUTTON_LEDS:
                 return new Quirk({
                     id: id,
@@ -103,6 +154,7 @@ class RoborockQuirkFactory {
 }
 
 RoborockQuirkFactory.KNOWN_QUIRKS = {
+    AUTO_EMPTY_LENGTH: "7e33281f-d1bd-4e11-a100-b2c792284883",
     BUTTON_LEDS: "57ffd1d3-306e-4451-b89c-934ec917fe7e",
     STATUS_LED: "1daf5179-0689-48a5-8f1b-0a23e11836dc"
 };

--- a/backend/lib/robots/roborock/RoborockS7ValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockS7ValetudoRobot.js
@@ -43,7 +43,9 @@ class RoborockS7ValetudoRobot extends RoborockGen4ValetudoRobot {
         }));
 
         [
-            capabilities.RoborockKeyLockCapability,
+            capabilities.RoborockAutoEmptyDockAutoEmptyControlCapability,
+            capabilities.RoborockAutoEmptyDockManualTriggerCapability,
+            capabilities.RoborockKeyLockCapability
         ].forEach(capability => {
             this.registerCapability(new capability({robot: this}));
         });
@@ -54,6 +56,7 @@ class RoborockS7ValetudoRobot extends RoborockGen4ValetudoRobot {
         this.registerCapability(new QuirksCapability({
             robot: this,
             quirks: [
+                quirkFactory.getQuirk(RoborockQuirkFactory.KNOWN_QUIRKS.AUTO_EMPTY_LENGTH),
                 quirkFactory.getQuirk(RoborockQuirkFactory.KNOWN_QUIRKS.BUTTON_LEDS),
                 quirkFactory.getQuirk(RoborockQuirkFactory.KNOWN_QUIRKS.STATUS_LED)
             ]

--- a/backend/lib/robots/roborock/capabilities/RoborockAutoEmptyDockAutoEmptyControlCapability.js
+++ b/backend/lib/robots/roborock/capabilities/RoborockAutoEmptyDockAutoEmptyControlCapability.js
@@ -1,0 +1,31 @@
+const AutoEmptyDockAutoEmptyControlCapability = require("../../../core/capabilities/AutoEmptyDockAutoEmptyControlCapability");
+
+/**
+ * @extends AutoEmptyDockAutoEmptyControlCapability<import("../RoborockValetudoRobot")>
+ */
+class RoborockAutoEmptyDockAutoEmptyControlCapability extends AutoEmptyDockAutoEmptyControlCapability {
+    /**
+     *
+     * @returns {Promise<boolean>}
+     */
+    async isEnabled() {
+        const res = await this.robot.sendCommand("get_dust_collection_switch_status", [], {});
+        return res.status === 1;
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async enable() {
+        await this.robot.sendCommand("set_dust_collection_switch_status", { "status": 1 }, {});
+    }
+
+    /**
+     * @returns {Promise<void>}
+     */
+    async disable() {
+        await this.robot.sendCommand("set_dust_collection_switch_status", { "status": 0 }, {});
+    }
+}
+
+module.exports = RoborockAutoEmptyDockAutoEmptyControlCapability;

--- a/backend/lib/robots/roborock/capabilities/RoborockAutoEmptyDockManualTriggerCapability.js
+++ b/backend/lib/robots/roborock/capabilities/RoborockAutoEmptyDockManualTriggerCapability.js
@@ -1,0 +1,12 @@
+const AutoEmptyDockManualTriggerCapability = require("../../../core/capabilities/AutoEmptyDockManualTriggerCapability");
+
+/**
+ * @extends AutoEmptyDockManualTriggerCapability<import("../RoborockValetudoRobot")>
+ */
+class RoborockAutoEmptyDockManualTriggerCapability extends AutoEmptyDockManualTriggerCapability {
+    async triggerAutoEmpty() {
+        await this.robot.sendCommand("app_start_collect_dust", [], {});
+    }
+}
+
+module.exports = RoborockAutoEmptyDockManualTriggerCapability;

--- a/backend/lib/robots/roborock/capabilities/index.js
+++ b/backend/lib/robots/roborock/capabilities/index.js
@@ -1,4 +1,6 @@
 module.exports = {
+    RoborockAutoEmptyDockAutoEmptyControlCapability: require("./RoborockAutoEmptyDockAutoEmptyControlCapability"),
+    RoborockAutoEmptyDockManualTriggerCapability: require("./RoborockAutoEmptyDockManualTriggerCapability"),
     RoborockBasicControlCapability: require("./RoborockBasicControlCapability"),
     RoborockCarpetModeControlCapability: require("./RoborockCarpetModeControlCapability"),
     RoborockCombinedVirtualRestrictionsCapability: require("./RoborockCombinedVirtualRestrictionsCapability"),


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [x] Capability implementation for existing core capability
- [ ] New robot implementation

<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

I bought an Auto Empty Dock for my Roborock S7 and since it's a non-supported robot, there was no way to control the dock in any manner via Valetudo.
That's why I decided to simply have a look and see if I can add it myself. 
I stumbling upon [this Reddit post](https://www.reddit.com/r/Roborock/comments/oyur9z/s7_auto_empty_dock_home_automation/) which pointed to [this Github comment](https://github.com/rytilahti/python-miio/issues/1107#issuecomment-893867891) that contained the necessary commands to control everything. So all that was left to do was to add the appropriate code to valetudo.

Newly added stuff:

**Feature Implementations:**

- AutoEmptyDockAutoEmptyControlCapability
- AutoEmptyDockManualTriggerCapability

**New Quirk AUTO_EMPTY_LENGTH:**
Lets you control the duration of the auto emptying process when it is triggered by the robot itself, just as in the roborock app.