### PR TITLE
supported-robots: Update Dreame W10 info with mapping pass and pin header quirks

### DIFF
--- a/docs/_pages/general/supported-robots.md
+++ b/docs/_pages/general/supported-robots.md
@@ -242,6 +242,10 @@ Rooting is fairly easy, only requiring a 3.3v USB UART Adapter and almost no dis
 Because of its port placement, it can be a bit difficult to connect the required cables for rooting.<br/>
 If you're struggling to do that, consider removing the Lid to gain better access to the connector.
 
+While the robot is on its wheels and the front is the far side, the BOOTSEL pin is the top right pin in the housing. 
+
+This vacuum will not run a mapping pass while the mop pads are installed.
+
 Rooting instructions:
 - [UART](https://valetudo.cloud/pages/installation/dreame.html#uart)
 


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [x] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

Right now, the mop pad mapping issue is undocumented and the pin header orientation as well. This should help ease some of the Telegram support burden for this mop.