### PR TITLE
Add mop pattern quirk to Viomi V7

### DIFF
--- a/backend/lib/robots/viomi/ViomiV7ValetudoRobot.js
+++ b/backend/lib/robots/viomi/ViomiV7ValetudoRobot.js
@@ -21,7 +21,8 @@ class ViomiV7ValetudoRobot extends ViomiValetudoRobot {
         this.registerCapability(new QuirksCapability({
             robot: this,
             quirks: [
-                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.BUTTON_LEDS)
+                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.BUTTON_LEDS),
+                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.MOP_PATTERN)
             ]
         }));
     }


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [x] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


# Description (Type A)

Viomi V7 supports the Y-pattern mopping. This simply add the existing quirk to the device type. See below:

```
$ miiocli device --ip <snip> --token <snip> info
Model: viomi.vacuum.v7
Hardware version: Linux
Firmware version: 3.5.3_0047

$ mirobo --ip <snip> --token <snip> raw-command get_prop '["mop_route"]'
Sending cmd get_prop with params ['mop_route']
WARNING:miio.device:Found an unsupported model 'viomi.vacuum.v7' for class 'RoborockVacuum'. If this is working for you, please open an issue at https://github.com/rytilahti/python-miio/
[1]
```