### PR TITLE
fix(webserver): Add return after failing to load OpenAPI spec

### DIFF
--- a/backend/lib/webserver/WebServer.js
+++ b/backend/lib/webserver/WebServer.js
@@ -245,6 +245,7 @@ class WebServer {
             spec = JSON.parse(fs.readFileSync(path.join(__dirname, "../res/valetudo.openapi.schema.json")).toString());
         } catch (e) {
             Logger.warn("Failed to load OpenApi spec. Swagger endpoint and payload validation will be unavailable.", e.message);
+            return;
         }
 
 


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

The `spec` variable is being used after the spec fails to load, which causes a TypeError when developing valetudo (without the spec having been generated):

```
[2023-01-14T17:30:42.496Z] [WARN] Failed to load OpenApi spec. Swagger endpoint and payload validation will be unavailable. ENOENT: no such file or directory, open '/home/alufers/Projects/Contrib/Valetudo/backend/lib/res/valetudo.openapi.schema.json'
/home/alufers/Projects/Contrib/Valetudo/backend/lib/webserver/WebServer.js:254
        Object.keys(spec.paths).forEach(pathName => {
                         ^

TypeError: Cannot read properties of undefined (reading 'paths')
    at WebServer.loadApiSpec (/home/alufers/Projects/Contrib/Valetudo/backend/lib/webserver/WebServer.js:254:26)
    at new WebServer (/home/alufers/Projects/Contrib/Valetudo/backend/lib/webserver/WebServer.js:96:14)
    at new Valetudo (/home/alufers/Projects/Contrib/Valetudo/backend/lib/Valetudo.js:82:26)
    at Object.<anonymous> (/home/alufers/Projects/Contrib/Valetudo/backend/index.js:6:18)
    at Module._compile (node:internal/modules/cjs/loader:1205:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1259:10)
    at Module.load (node:internal/modules/cjs/loader:1068:32)
    at Module._load (node:internal/modules/cjs/loader:909:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:82:12)
    at node:internal/main/run_main_module:23:47
```

I think the intention was to allow Valetudo to run without the OpenAPI spec generated, but this error prevents this. I have added a return statement to bail out when this happens.
