### PR TITLE
docs: Add description on how to copy the firmware file with scp to the robot

### DIFF
--- a/docs/_pages/usage/upgrading.md
+++ b/docs/_pages/usage/upgrading.md
@@ -27,7 +27,7 @@ If you're using an S5 or V1, the recommended way to upgrade Valetudo is to flash
 
    - Option 2: Download the tar.gz file and copy it with scp from your device to the robot
 
-      - Execute the following to copy the file
+      - Examples of how to copy the file to the robot
 
          ```sh
          #Example 1 

--- a/docs/_pages/usage/upgrading.md
+++ b/docs/_pages/usage/upgrading.md
@@ -32,9 +32,6 @@ If you're using an S5 or V1, the recommended way to upgrade Valetudo is to flash
          ```sh
          #Example 1 
          scp -i <privatekey.id_rsa> <file.tar.gz> user@<ip adress>:/mnt/data
-         ```
-
-         ```sh
          #Example 2 with values
          scp -i YOUR_PRIVATEKEY.id_rsa roborock.vacuum.s5_2034_fw.tar.gz root@192.168.8.1:/mnt/data
          ```

--- a/docs/_pages/usage/upgrading.md
+++ b/docs/_pages/usage/upgrading.md
@@ -24,17 +24,33 @@ If you're using an S5 or V1, the recommended way to upgrade Valetudo is to flash
       wget <url to tar from dustbuilder>
       tar xzf <file.tar.gz>
       ```
-   - Option 2: Download the tar.gz file and copy it with for example scp from your laptop to the robot
-      ```sh
-      scp -i YOUR_PRIVATEKEY.id_rsa roborock.vacuum.s5_2034_fw.tar.gz root@192.168.8.1:/mnt/data
-      tar xzf <file.tar.gz>
-      ```
+
+   - Option 2: Download the tar.gz file and copy it with scp from your device to the robot
+
+      - Execute the following to copy the file
+
+         ```sh
+         #Example 1 
+         scp -i <privatekey.id_rsa> <file.tar.gz> user@<ip adress>:/mnt/data
+         ```
+
+         ```sh
+         #Example 2 with values
+         scp -i YOUR_PRIVATEKEY.id_rsa roborock.vacuum.s5_2034_fw.tar.gz root@192.168.8.1:/mnt/data
+         ```
+
+      - Execute the following from the robot
+
+         ```sh
+         tar xzf <file.tar.gz>
+         ```
+
 4. The robot has two systems, you cannot update a system whilst it is in use. You will be in system A by default, allowing you to update system B. Update system B (from system A) then reboot into system B:
 ```sh
 ./install_b.sh
 reboot
 ```
-5. Reconnect to your robot via SSH. You'll now be in system B, allowing you to update system A. Update system A (from system B) then reboot back into system A for normal operation:
+1. Reconnect to your robot via SSH. You'll now be in system B, allowing you to update system A. Update system A (from system B) then reboot back into system A for normal operation:
 ```sh
 cd /mnt/data
 ./install_a.sh

--- a/docs/_pages/usage/upgrading.md
+++ b/docs/_pages/usage/upgrading.md
@@ -31,7 +31,7 @@ If you're using an S5 or V1, the recommended way to upgrade Valetudo is to flash
 
          ```sh
          #Example 1 
-         scp -i <privatekey.id_rsa> <file.tar.gz> user@<ip adress>:/mnt/data
+         scp -i <privatekey.id_rsa> <file.tar.gz> user@<ip address>:/mnt/data
          #Example 2 with values
          scp -i YOUR_PRIVATEKEY.id_rsa roborock.vacuum.s5_2034_fw.tar.gz root@192.168.8.1:/mnt/data
          ```

--- a/docs/_pages/usage/upgrading.md
+++ b/docs/_pages/usage/upgrading.md
@@ -47,7 +47,7 @@ If you're using an S5 or V1, the recommended way to upgrade Valetudo is to flash
 ./install_b.sh
 reboot
 ```
-1. Reconnect to your robot via SSH. You'll now be in system B, allowing you to update system A. Update system A (from system B) then reboot back into system A for normal operation:
+5. Reconnect to your robot via SSH. You'll now be in system B, allowing you to update system A. Update system A (from system B) then reboot back into system A for normal operation:
 ```sh
 cd /mnt/data
 ./install_a.sh

--- a/docs/_pages/usage/upgrading.md
+++ b/docs/_pages/usage/upgrading.md
@@ -18,11 +18,17 @@ If you're using an S5 or V1, the recommended way to upgrade Valetudo is to flash
 1. Select the `Build for manual installation (requires SSH to install)` option in the [Dustbuilder](https://builder.dontvacuum.me/). You will then receive a link to a tar.gz archive by email.
 2. Login to your robot via SSH.
 3. Download the tar.gz file to the `/mnt/data` folder and extract it:
-```sh
-cd /mnt/data
-wget <url to tar from dustbuilder>
-tar xzf <file.tar.gz>
-```
+   - Option 1: Download tar.gz with wget
+      ```sh
+      cd /mnt/data
+      wget <url to tar from dustbuilder>
+      tar xzf <file.tar.gz>
+      ```
+   - Option 2: Download the tar.gz file and copy it with for example scp from your laptop to the robot
+      ```sh
+      scp -i YOUR_PRIVATEKEY.id_rsa roborock.vacuum.s5_2034_fw.tar.gz root@192.168.8.1:/mnt/data
+      tar xzf <file.tar.gz>
+      ```
 4. The robot has two systems, you cannot update a system whilst it is in use. You will be in system A by default, allowing you to update system B. Update system B (from system A) then reboot into system B:
 ```sh
 ./install_b.sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,7 @@ Also, make sure to check out the companion apps section.
 ![image](https://user-images.githubusercontent.com/974410/211155880-ff184776-86fe-4c2f-9556-4d556cfa12f4.png)
 
 ### Join the Discussion
-* [Valetudo Telegram group](https://t.me/+uGuDHt0dNCVmODli)
+* [Valetudo Telegram group](https://t.me/+Wlt6LOE82dMwNmQy)
 * \#valetudo on irc.libera.chat
 
 ### Expectation Management


### PR DESCRIPTION
## Type of change
- [x] Docs

<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)
Hi, this pull request would add a section (Option 2) which describes how to copy the firmware file with scp from your device to the robot 

Motivation:
I just installed Valetudo on my S5 and for the upgrade from "factory firmware" → 1886 → 2008 I used "valetudo-helper-miioota". From 2008 to 2034 the "valetudo-helper-miioota" tool does not work for me (I think 2008 is blocking the upgrade, I have read in other forums, that other people are facing the same issue) so I was a bit confused on how to get the firmware file to the robot.

I know, there is a "netcat"  server available → Text from DustBuilder:
_Your job has been added on the blockchain and your firmware image roborock.vacuum.s5_2034_fw.tar.gz is ready.
URL of folder, including the netcat server:_

But for me, it was easier to copy the file with scp, so I thought, maybe, we can add this option as an alternative, which might help other people.

BTW: This is my first contribution, if anything is missing or not as good as it should, please reach out, I'm trying my best 😊
