### PR TITLE
Fix typo in VoicepackHelp.ts

### DIFF
--- a/frontend/src/robot/capabilities/res/VoicepackHelp.ts
+++ b/frontend/src/robot/capabilities/res/VoicepackHelp.ts
@@ -17,6 +17,6 @@ The type of hash differs depending on the firmware.
 Furthermore, you'll also need to specify a language code. That value largely doesn't matter much unless you use a reserved code.
 "EN", "CN" etc are often codes reserved for the inbuilt voice packs of the firmware.
 
-Usually it's possible to revert to the inititally installed voice pack by specifying one of those inbuilt voicepack codes during the install.
+Usually it's possible to revert to the initially installed voice pack by specifying one of those inbuilt voicepack codes during the install.
 
 `;


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [x] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

This PR fixes a small typo in the help text in VoicepackHelp.ts
 
