### PR TITLE
docs: Fix typo seperate -> separate

### DIFF
--- a/backend/lib/core/capabilities/Capability.js
+++ b/backend/lib/core/capabilities/Capability.js
@@ -23,7 +23,7 @@ class Capability {
 
     /**
      * This may contain capability-specific information, restrictions etc, which can't be handled
-     * by splitting the problem into seperate capabilities
+     * by splitting the problem into separate capabilities
      *
      * @returns {object}
      */

--- a/docs/_pages/companion_apps/node-red-contrib-valetudo.md
+++ b/docs/_pages/companion_apps/node-red-contrib-valetudo.md
@@ -5,6 +5,6 @@ order: 19
 ---
 # node-red-contrib-valetudo
 
-A node-red node to convert Valetudo map_data to a png image which can be send to a dashboard template node.
+A node-red node to convert Valetudo map_data to a png image which can be sent to a dashboard template node.
 
 [https://github.com/alexkn/node-red-contrib-valetudo](https://github.com/alexkn/node-red-contrib-valetudo)

--- a/docs/_pages/development/valetudo-core-concepts.md
+++ b/docs/_pages/development/valetudo-core-concepts.md
@@ -50,7 +50,7 @@ implementations (e.g. `RoborockGoToLocationCapability`).
 
 Capabilities may only be implemented fully so that we can be certain, that a Robot with a `GoToLocationCapability` will always be able to
 do everything the `GoToLocationCapability`.
-Therefore, its better to split some features into seperate Capabilities, since it's always possible for a robot to have
+Therefore, its better to split some features into separate Capabilities, since it's always possible for a robot to have
 multiple capabilities but never only half of one.
 
 

--- a/docs/_pages/usage/capabilities-overview.md
+++ b/docs/_pages/usage/capabilities-overview.md
@@ -74,7 +74,7 @@ Some robots may allow for or even require a mapping pass instead of building the
 This capability is used to start the mapping process.
 
 Don't be confused if your robot doesn't have this capability.
-Usually, they will build the map during cleanup without requiring a seperate mapping pass.
+Usually, they will build the map during cleanup without requiring a separate mapping pass.
 
 ## MapResetCapability <a id="MapResetCapability"></a>
 


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [x] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
 

# Description (Type A)

Fixes typos I encountered while reading code/docs.
 
