### PR TITLE
correct the path of the configuration file /mnt/data/valetudo_config.…

### DIFF
--- a/docs/_pages/development/building-and-modifying-valetudo.md
+++ b/docs/_pages/development/building-and-modifying-valetudo.md
@@ -64,7 +64,7 @@ When running on the robot itself, these are usually detected automatically.
 
 | Vendor   | Config Key    | Robot Location                          | Robot Key |
 |----------|---------------|-----------------------------------------|-----------|
-| Roborock | valetudo.conf | /mnt/data/valetudo/valetudo_config.json |           |
+| Roborock | valetudo.conf | /mnt/data/valetudo_config.json          |           |
 |          | deviceId      | /mnt/default/device.conf                | did       |
 |          | cloudSecret   | /mnt/default/device.conf                | key       |
 |          | localSecret   | /mnt/data/miio/device.token             |           |


### PR DESCRIPTION
…json

I have an roborock S50 (S5) and i notice there is no valetudo folder inside data and the configuration file is at /mnt/data/valetudo_config.json and not at /mnt/data/valetudo/valetudo_config.json

## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [x] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


<!-- Please delete the description section that doesn't match your type of change -->

# Description (Type A)

Please include a summary of the change and which issue is fixed (if applicable).
Please also include relevant motivation and context.
 
<!-- Delete if there is none -->
Fixes # (issue)

# Description (Type B)
<!--
    While of course appreciated, please don't open PRs with features without discussing them first.
    _Especially_ if it's a new capability.

    New features will only be accepted if the scope as well as the requirements have been defined in a separate discussion
    Please only open the PR after it is clear what it should do and what it shouldn't.
    
    PRs won't be merged otherwise
-->

<!-- This link is required -->
Feature discussion thread:
