### PR TITLE
docs: Fix timers doc regarding lack of NTP

### DIFF
--- a/frontend/src/valetudo/timers/res/TimersHelp.ts
+++ b/frontend/src/valetudo/timers/res/TimersHelp.ts
@@ -3,8 +3,10 @@ export const TimersHelp = `
 ## Timers
 
 Timers allow you to execute a task at a specified time (UTC).<br/>
-To operate, they require the system time to be synced using the NTP-Client built into Valetudo.
-If that is disabled or unable to reach the configured NTP server, no timers will be executed.
+To operate, they require the system time to be synced using the NTP client built into Valetudo.
+If it is unable to reach the configured NTP server, no timers will be
+executed unless the NTP client was disabled explicitly which would
+imply the user is responsible for providing time by other means.
 
 **Please note that timers are evaluated and stored as UTC. They are only displayed in your current browser timezone
 for your convenience.**


### PR DESCRIPTION
Since the timers were (re)introduced in 7b8c37ad1 running them with NTP server explicitly disabled was supported and intended. Fix the doc accordingly.

## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [x ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature
