### PR TITLE
Add map_flag parameter 

### DIFF
--- a/backend/lib/robots/roborock/RoborockQuirkFactory.js
+++ b/backend/lib/robots/roborock/RoborockQuirkFactory.js
@@ -215,7 +215,7 @@ class RoborockQuirkFactory {
                     },
                     setter: async (value) => {
                         if (value === "trigger") {
-                            await this.robot.sendCommand("manual_segment_map", [], {timeout: 10000});
+                            await this.robot.sendCommand("manual_segment_map", [{"map_flag":-1}], {timeout: 10000});
 
                             this.robot.pollMap();
                         }


### PR DESCRIPTION
## Type of change

Type A:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [ ] Capability implementation for existing core capability
- [ ] New robot implementation
  
Type B:
- [ ] New capability
- [ ] New core feature


# Description (Type A)
The new Manual Map Segment Trigger quirk fails with no parameter given. I'm adding the same parameter that is found in https://github.com/Hypfer/Valetudo/blob/1d2ad47e9d49eac71f0621d2aa0444acf871acec/backend/lib/robots/roborock/capabilities/RoborockMultiMapMapResetCapability.js#L27 

Fixes # 1800