### PR TITLE
feat(vendor.viomi): Support outline cleaning mode

### DIFF
--- a/backend/lib/robots/viomi/ViomiQuirkFactory.js
+++ b/backend/lib/robots/viomi/ViomiQuirkFactory.js
@@ -94,6 +94,51 @@ class ViomiQuirkFactory {
                         return this.robot.sendCommand("set_moproute", [val], {});
                     }
                 });
+            case ViomiQuirkFactory.KNOWN_QUIRKS.OUTLINE_MODE:
+                return new Quirk({
+                    id: id,
+                    title: "Vacuum only around the edges",
+                    description: "When enabled, vacuum only around the edges of the room. This only works in \"Vacuum\" mode. It will be disabled after the next cleaning operation.",
+                    options: ["on", "off"],
+                    getter: async () => {
+                        const res = await this.robot.sendCommand("get_prop", ["mode"], {});
+
+                        if (!(Array.isArray(res) && res.length === 1)) {
+                            throw new Error(`Received invalid response: ${res}`);
+                        } else {
+                            switch (res[0]) {
+                                case 2:  // Edge cleaning mode
+                                    this.robot.ephemeralState.outlineModeEnabled = true;
+                                    return "on";
+                                case 0:  // Regular cleaning mode
+                                case 5:  // Manual control mode
+                                    this.robot.ephemeralState.outlineModeEnabled = false;
+                                    return "off";
+                                default:
+                                    throw new Error(`Received invalid value ${res}`);
+                            }
+                        }
+
+                    },
+                    setter: async (value) => {
+                        let val;
+
+                        switch (value) {
+                            case "on":
+                                val = 2;
+                                this.robot.ephemeralState.outlineModeEnabled = true;
+                                break;
+                            case "off":
+                                val = 0;
+                                this.robot.ephemeralState.outlineModeEnabled = false;
+                                break;
+                            default:
+                                throw new Error(`Received invalid value ${value}`);
+                        }
+
+                        return this.robot.sendCommand("set_mode", [val], {});
+                    }
+                });
             default:
                 throw new Error(`There's no quirk with id ${id}`);
         }
@@ -102,7 +147,8 @@ class ViomiQuirkFactory {
 
 ViomiQuirkFactory.KNOWN_QUIRKS = {
     BUTTON_LEDS: "977c5972-1f12-4ef1-9622-ce71fd085193",
-    MOP_PATTERN: "0ae06cb4-8cc7-429f-95fb-f3d0bbfc06de"
+    MOP_PATTERN: "0ae06cb4-8cc7-429f-95fb-f3d0bbfc06de",
+    OUTLINE_MODE: "061b826c-417c-46a0-b6ad-807260cd4f70",
 };
 
 module.exports = ViomiQuirkFactory;

--- a/backend/lib/robots/viomi/ViomiV6ValetudoRobot.js
+++ b/backend/lib/robots/viomi/ViomiV6ValetudoRobot.js
@@ -27,7 +27,8 @@ class ViomiV6ValetudoRobot extends ViomiValetudoRobot {
             robot: this,
             quirks: [
                 quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.BUTTON_LEDS),
-                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.MOP_PATTERN)
+                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.MOP_PATTERN),
+                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.OUTLINE_MODE),
             ]
         }));
     }

--- a/backend/lib/robots/viomi/ViomiV7ValetudoRobot.js
+++ b/backend/lib/robots/viomi/ViomiV7ValetudoRobot.js
@@ -22,7 +22,8 @@ class ViomiV7ValetudoRobot extends ViomiValetudoRobot {
             robot: this,
             quirks: [
                 quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.BUTTON_LEDS),
-                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.MOP_PATTERN)
+                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.MOP_PATTERN),
+                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.OUTLINE_MODE),
             ]
         }));
     }

--- a/backend/lib/robots/viomi/ViomiV8ValetudoRobot.js
+++ b/backend/lib/robots/viomi/ViomiV8ValetudoRobot.js
@@ -26,7 +26,8 @@ class ViomiV8ValetudoRobot extends ViomiValetudoRobot {
         this.registerCapability(new QuirksCapability({
             robot: this,
             quirks: [
-                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.BUTTON_LEDS)
+                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.BUTTON_LEDS),
+                quirkFactory.getQuirk(ViomiQuirkFactory.KNOWN_QUIRKS.OUTLINE_MODE),
             ]
         }));
     }

--- a/backend/lib/robots/viomi/ViomiValetudoRobot.js
+++ b/backend/lib/robots/viomi/ViomiValetudoRobot.js
@@ -44,6 +44,7 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
             carpetModeEnabled: undefined,
             lastOperationType: null,
             lastOperationAdditionalParams: [],
+            outlineModeEnabled: false,
             vendorMapId: 0
         };
 
@@ -276,6 +277,8 @@ class ViomiValetudoRobot extends MiioValetudoRobot {
                 }
             }
 
+            // Need to remember this since we have to send it back when starting a cleaning operation
+            this.ephemeralState.outlineModeEnabled = data["mode"] === 2;
 
             if (error !== undefined) {
                 if (error.value === stateAttrs.StatusStateAttribute.VALUE.ERROR) {

--- a/backend/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
+++ b/backend/lib/robots/viomi/capabilities/ViomiBasicControlCapability.js
@@ -37,7 +37,11 @@ class ViomiBasicControlCapability extends BasicControlCapability {
             case stateAttrs.PresetSelectionStateAttribute.MODE.MOP:
                 return attributes.ViomiMovementMode.MOP;
             case stateAttrs.PresetSelectionStateAttribute.MODE.VACUUM:
-                return attributes.ViomiMovementMode.VACUUM;
+                if (outline) {
+                    return attributes.ViomiMovementMode.OUTLINE;
+                } else {
+                    return attributes.ViomiMovementMode.VACUUM;
+                }
             default:
                 return attributes.ViomiMovementMode.VACUUM;
         }
@@ -52,7 +56,7 @@ class ViomiBasicControlCapability extends BasicControlCapability {
      * @returns {Promise<void>}
      */
     async setModeWithSegments(operation, segmentIds) {
-        const movementMode = this.getVacuumMovementMode();
+        const movementMode = this.getVacuumMovementMode(this.robot.ephemeralState.outlineModeEnabled);
 
         if (segmentIds === undefined || segmentIds === null) {
             segmentIds = [];


### PR DESCRIPTION
## Type of change

Type A:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] UI Feature
- [ ] Refactor/Code Cleanup
- [ ] Docs
- [x] Capability implementation for existing core capability
- [ ] New robot implementation

# Description (Type A)

This PR implements the "outline-only" vacuuming mode for Viomi. I'm assuming all Viomis support it.

Let me know what you think about the implementation choices, I'm aware it's not ideal, I'd like your feedback.