### PR TITLE
Fix MQTT area statistics value sent in mm^2 instead of cm^2

### DIFF
--- a/backend/lib/mqtt/capabilities/CurrentStatisticsCapabilityMqttHandle.js
+++ b/backend/lib/mqtt/capabilities/CurrentStatisticsCapabilityMqttHandle.js
@@ -77,7 +77,7 @@ class CurrentStatisticsCapabilityMqttHandle extends CapabilityMqttHandle {
                             getter: async () => {
                                 return this.controller.hassAnchorProvider.getAnchor(
                                     HassAnchor.ANCHOR.CURRENT_STATISTICS_AREA
-                                ).getValue();
+                                ).getValue() / 100;
                             }
                         }).also((prop) => {
                             this.controller.withHass((hass => {

--- a/backend/lib/mqtt/capabilities/TotalStatisticsCapabilityMqttHandle.js
+++ b/backend/lib/mqtt/capabilities/TotalStatisticsCapabilityMqttHandle.js
@@ -77,7 +77,7 @@ class TotalStatisticsCapabilityMqttHandle extends CapabilityMqttHandle {
                             getter: async () => {
                                 return this.controller.hassAnchorProvider.getAnchor(
                                     HassAnchor.ANCHOR.TOTAL_STATISTICS_AREA
-                                ).getValue();
+                                ).getValue() / 100;
                             }
                         }).also((prop) => {
                             this.controller.withHass((hass => {


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs
- [ ] Refactor/Code Cleanup

# Description

This PR fixes an issue with area statistics values sent via MQTT. The current/total area statistics values are sent in `mm^2` instead of `cm^2` as is advertised in the MQTT discovery.

I own an Z10 Pro that is connected to HomeAssistant, which shows the area statistics value correctly on the Valetudo frontend, e.g. `002.00 m^2`. In HomeAssistant however, I see `20,000 cm^2` which is not correct.

I'm aware that there could be multiple solutions to this problem, e.g. changing the `unit_of_measurement` that the robot advertises to HomeAssistant. I however chose to go the route of calculating the correct value for the given `unit_of_measurement`, since I think having `mm^2` would be overly precise.

**Disclaimer:** Since the proposed changes are applied to the general `MqttHandle`s, I believe this would affect other robots as well. I don't have other robots to confirm they have the same issue. However I saw that the Valetudo frontend received the same value as is sent via MQTT (e.g. `20,000`) - but the Valetudo frontend computes the correct value (in `m^2` for display. Therefore I assumed that making the propsed changes was the correct call.