### PR TITLE
Add device_class attribute to battery and WiFi sensors for Home Assistant 

### DIFF
--- a/backend/lib/mqtt/capabilities/WifiConfigurationCapabilityMqttHandle.js
+++ b/backend/lib/mqtt/capabilities/WifiConfigurationCapabilityMqttHandle.js
@@ -1,6 +1,7 @@
 const CapabilityMqttHandle = require("./CapabilityMqttHandle");
 const ComponentType = require("../homeassistant/ComponentType");
 const DataType = require("../homie/DataType");
+const DeviceClass = require("../homeassistant/DeviceClass");
 const EntityCategory = require("../homeassistant/EntityCategory");
 const HassAnchor = require("../homeassistant/HassAnchor");
 const InLineHassComponent = require("../homeassistant/components/InLineHassComponent");
@@ -96,7 +97,8 @@ class WifiConfigurationCapabilityMqttHandle extends CapabilityMqttHandle {
                             HassAnchor.REFERENCE.HASS_WIFI_CONFIG_ATTRS
                         ),
                         json_attributes_template: "{{ value_json.attributes | to_json }}",
-                        entity_category: EntityCategory.DIAGNOSTIC
+                        entity_category: EntityCategory.DIAGNOSTIC,
+                        device_class: DeviceClass.SIGNAL_STRENGTH
                     },
                     topics: {
                         "": {

--- a/backend/lib/mqtt/homeassistant/DeviceClass.js
+++ b/backend/lib/mqtt/homeassistant/DeviceClass.js
@@ -1,0 +1,61 @@
+/**
+ * Retrieved from https://github.com/home-assistant/core/blob/8b1cfbc46cc79e676f75dfa4da097a2e47375b6f/homeassistant/components/sensor/const.py#L64-L416 on 2023-10-25.
+ *
+ * See also https://developers.home-assistant.io/docs/core/entity/#generic-properties
+ *
+ * @enum {string}
+ */
+const DeviceClass = Object.freeze({
+    DATE: "date",
+    ENUM: "enum",
+    TIMESTAMP: "timestamp",
+    APPARENT_POWER: "apparent_power",
+    AQI: "aqi",
+    ATMOSPHERIC_PRESSURE: "atmospheric_pressure",
+    BATTERY: "battery",
+    CO: "carbon_monoxide",
+    CO2: "carbon_dioxide",
+    CURRENT: "current",
+    DATA_RATE: "data_rate",
+    DATA_SIZE: "data_size",
+    DISTANCE: "distance",
+    DURATION: "duration",
+    ENERGY: "energy",
+    ENERGY_STORAGE: "energy_storage",
+    FREQUENCY: "frequency",
+    GAS: "gas",
+    HUMIDITY: "humidity",
+    ILLUMINANCE: "illuminance",
+    IRRADIANCE: "irradiance",
+    MOISTURE: "moisture",
+    MONETARY: "monetary",
+    NITROGEN_DIOXIDE: "nitrogen_dioxide",
+    NITROGEN_MONOXIDE: "nitrogen_monoxide",
+    NITROUS_OXIDE: "nitrous_oxide",
+    OZONE: "ozone",
+    PH: "ph",
+    PM1: "pm1",
+    PM10: "pm10",
+    PM25: "pm25",
+    POWER_FACTOR: "power_factor",
+    POWER: "power",
+    PRECIPITATION: "precipitation",
+    PRECIPITATION_INTENSITY: "precipitation_intensity",
+    PRESSURE: "pressure",
+    REACTIVE_POWER: "reactive_power",
+    SIGNAL_STRENGTH: "signal_strength",
+    SOUND_PRESSURE: "sound_pressure",
+    SPEED: "speed",
+    SULPHUR_DIOXIDE: "sulphur_dioxide",
+    TEMPERATURE: "temperature",
+    VOLATILE_ORGANIC_COMPOUNDS: "volatile_organic_compounds",
+    VOLATILE_ORGANIC_COMPOUNDS_PARTS: "volatile_organic_compounds_parts",
+    VOLTAGE: "voltage",
+    VOLUME: "volume",
+    VOLUME_STORAGE: "volume_storage",
+    WATER: "water",
+    WEIGHT: "weight",
+    WIND_SPEED: "wind_speed"
+});
+
+module.exports = DeviceClass;

--- a/backend/lib/mqtt/status/BatteryStateMqttHandle.js
+++ b/backend/lib/mqtt/status/BatteryStateMqttHandle.js
@@ -1,5 +1,6 @@
 const ComponentType = require("../homeassistant/ComponentType");
 const DataType = require("../homie/DataType");
+const DeviceClass = require("../homeassistant/DeviceClass");
 const EntityCategory = require("../homeassistant/EntityCategory");
 const HassAnchor = require("../homeassistant/HassAnchor");
 const InLineHassComponent = require("../homeassistant/components/InLineHassComponent");
@@ -57,7 +58,8 @@ class BatteryStateMqttHandle extends RobotStateNodeMqttHandle {
                             state_topic: prop.getBaseTopic(),
                             icon: "mdi:battery",
                             entity_category: EntityCategory.DIAGNOSTIC,
-                            unit_of_measurement: Unit.PERCENT
+                            unit_of_measurement: Unit.PERCENT,
+                            device_class: DeviceClass.BATTERY
                         }
                     })
                 );


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs
- [ ] Refactor/Code Cleanup

# Description

This PR add the `device_class` attribute to the battery and WiFi sensors for Home Assistant. Having a proper `device_class` attribute allows HA to apply some extra styles to entity.

e.g. For battery level, the icon is color-coded depending on state and the device page shows the battery level

**Icon Colored**
![image](https://github.com/Hypfer/Valetudo/assets/6924622/0bcbdde9-3807-4307-a0ba-91d131040d62)
![image](https://github.com/Hypfer/Valetudo/assets/6924622/8ae8afc4-4f6f-4e0a-8868-846cbb79d9c5)

**Battery On Device Page**
![image](https://github.com/Hypfer/Valetudo/assets/6924622/bd4eca84-42af-4df0-9054-97119e42d0fc)

I didn't notice any obvious changes for the WiFi sensor to report here.

 ## Possible additional changes
 The following additional updates might be possible. 
 * Current Statistics Time -> DeviceClass.DURATION
 * Total Statistics Time -> DeviceClass.DURATION
 * Consumables -> DeviceClass.DURATION 
   * Only if `unit !== stateAttrs.ConsumableStateAttribute.UNITS.PERCENT`
* Status Flag -> Maybe DeviceClass.ENUM?
* Error -> Maybe DeviceClass.ENUM? 
  * Or maybe could be refactored to a binary sensor with BinarySensorDeviceClass.PROBLEM
  
There is also a BinarySensorDeviceClass which can be seen [here]( https://github.com/home-assistant/core/blob/f28c9221e63266a512a3bfef9a66c2dab6ccd96e/homeassistant/components/binary_sensor/__init__.py#L31C5-L116) but I didn't find an applicable classes to the current binary sensors. 

A future improvement could expose if an update is available with the UPDATE class.

