### PR TITLE
Update TLS wording in NTP Connectivity

### DIFF
--- a/frontend/src/options/connectivity/NTPConnectivity.tsx
+++ b/frontend/src/options/connectivity/NTPConnectivity.tsx
@@ -268,7 +268,7 @@ const NTPConnectivity = (): React.ReactElement => {
                     >
                         <Typography color="info">
                             Valetudo needs a synchronized clock for timers to work and the log timestamps to make sense.
-                            Furthermore, the integrated updater may not work if the clock is set wrongly due to SSL
+                            Furthermore, the integrated updater may not work if the clock is set wrongly due to TLS
                             certificates usually only being valid within a particular period of time.
                         </Typography>
                     </InfoBox>


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Docs
- [ ] Refactor/Code Cleanup

# Description

The terms TLS and SSL are sometimes used interchangeably, but hopefully no one is actually using SSL anymore, so this should be called TLS.