### PR TITLE
Fix loading images messing up anchors on the supported robot page

### DIFF
--- a/docs/_pages/general/supported-robots.md
+++ b/docs/_pages/general/supported-robots.md
@@ -112,7 +112,7 @@ Don't assume any compatibility of consumables or other parts as well as rooting 
 
 ### Xiaomi V1<a id="xiaomi_v1"></a>
 
-<img src="./img/robots/xiaomi/xiaomi_v1.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/xiaomi/xiaomi_v1.jpg"/>
 
 The Xiaomi V1 is made by Roborock. It is sold as:
 - Xiaomi Mi Robot Vacuum
@@ -140,7 +140,7 @@ If your robot is newer than that, full disassembly will be required.
 
 ### Xiaomi 1C<a id="xiaomi_1c"></a>
 
-<img src="img/robots/xiaomi/xiaomi_1c.jpg"/>
+<img class="aspect-ratio-4" src="img/robots/xiaomi/xiaomi_1c.jpg"/>
 
 The Xiaomi 1C is made by Dreame. It is sold as:
 - Mi Robot Vacuum-Mop
@@ -169,7 +169,7 @@ If you only see weird characters on the UART, try `500000` instead of `115200` a
 
 ### Xiaomi 1T<a id="xiaomi_1t"></a>
 
-<img src="img/robots/xiaomi/xiaomi_1t.jpg"/>
+<img class="aspect-ratio-4" src="img/robots/xiaomi/xiaomi_1t.jpg"/>
 
 The Xiaomi 1T is made by Dreame. It is sold as:
 - Mi Robot Vacuum-Mop 2 Pro+
@@ -196,7 +196,7 @@ Note that that factory reset will also remove Valetudo meaning that you will hav
 
 ### Xiaomi P2148<a id="xiaomi_p2148"></a>
 
-<img src="./img/robots/xiaomi/xiaomi_p2148.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/xiaomi/xiaomi_p2148.jpg"/>
 
 The Xiaomi P2148 is made by Dreame. It is sold as:
 - Mijia Robot Vacuum-Mop Ultra Slim
@@ -231,7 +231,7 @@ There is no reset button on this robot. Instead, press and hold the two buttons 
 
 ### Xiaomi Vacuum-Mop P<a id="xiaomi_vacuummop_p"></a>
 
-<img src="img/robots/xiaomi/xiaomi_vacuummop_p.jpg"/>
+<img class="aspect-ratio-4" src="img/robots/xiaomi/xiaomi_vacuummop_p.jpg"/>
 
 The Vacuum-Mop P is using the Viomi cloud stack but is actually made by 3irobotix.<br/>
 There are three robots with different IDs under this name, and they're all 3irobotix CRL-200S inside.<br/>
@@ -265,7 +265,7 @@ While Valetudo works with their model firmwares, the recommended rooting procedu
 
 ### Xiaomi Vacuum-Mop 2 Ultra<a id="xiaomi_p2150"></a>
 
-<img src="img/robots/xiaomi/xiaomi_p2150.jpg"/>
+<img class="aspect-ratio-4" src="img/robots/xiaomi/xiaomi_p2150.jpg"/>
 
 The Xiaomi Vacuum-Mop 2 Ultra is made by Dreame. It is sold as:
 - Mi Robot Vacuum-Mop 2 Ultra
@@ -288,7 +288,7 @@ All warranty seals stay intact.
 
 ### Xiaomi X10 Plus<a id="xiaomi_x10plus"></a>
 
-<img src="img/robots/xiaomi/xiaomi_x10plus.jpg"/>
+<img class="aspect-ratio-4" src="img/robots/xiaomi/xiaomi_x10plus.jpg"/>
 
 The Xiaomi Robot Vacuum X10 Plus is made by Dreame. It is sold as:
 - Xiaomi Robot Vacuum X10 Plus
@@ -311,7 +311,7 @@ All warranty seals stay intact.
 
 ### D9 <a id="dreame_d9"></a>
 
-<img src="./img/robots/dreame/dreame_d9.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_d9.jpg"/>
 
 The Dreame D9 is Dreame's first ever Lidar-based vacuum robot. It is sold as:
 - Dreame D9
@@ -332,7 +332,7 @@ All warranty seals stay intact.
 
 ### D9 Pro<a id="dreame_d9pro"></a>
 
-<img src="./img/robots/dreame/dreame_d9pro.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_d9pro.jpg"/>
 
 The Dreame D9 Pro is sold as:
 - Dreame D9 Pro
@@ -357,7 +357,7 @@ All warranty seals stay intact.
 
 ### F9 <a id="dreame_f9"></a>
 
-<img src="./img/robots/dreame/dreame_f9.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_f9.jpg"/>
 
 The Dreame F9 is sold as:
 - Dreame F9
@@ -378,7 +378,7 @@ All warranty seals stay intact.
 
 ### L10 Pro <a id="dreame_l10pro"></a>
 
-<img src="./img/robots/dreame/dreame_l10pro.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_l10pro.jpg"/>
 
 The Dreame L10 Pro is sold as:
 - Dreame L10 Pro
@@ -399,7 +399,7 @@ All warranty seals stay intact.
 
 ### Z10 Pro <a id="dreame_z10pro"></a>
 
-<img src="./img/robots/dreame/dreame_z10pro.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_z10pro.jpg"/>
 
 The Dreame Z10 Pro is sold as:
 - Dreame Z10 Pro
@@ -421,7 +421,7 @@ All warranty seals stay intact.
 
 ### W10 <a id="dreame_w10"></a>
 
-<img src="./img/robots/dreame/dreame_w10.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_w10.jpg"/>
 
 The Dreame W10 is sold as:
 - Dreame W10
@@ -459,7 +459,7 @@ For that, follow these steps:
 
 ### W10 Pro <a id="dreame_w10pro"></a>
 
-<img src="./img/robots/dreame/dreame_w10pro.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_w10pro.jpg"/>
 
 The Dreame W10 Pro is sold as:
 - Dreame W10 Pro
@@ -490,7 +490,7 @@ If you're rooting your W10 Pro, just run that command before setting up Valetudo
 
 ### L10s Ultra <a id="dreame_l10sultra"></a>
 
-<img src="./img/robots/dreame/dreame_l10sultra.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_l10sultra.jpg"/>
 
 The Dreame L10s Ultra is sold as:
 - Dreame L10s Ultra
@@ -511,7 +511,7 @@ All warranty seals stay intact.
 
 ### D10s Pro <a id="dreame_d10spro"></a>
 
-<img src="./img/robots/dreame/dreame_d10spro.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_d10spro.jpg"/>
 
 The Dreame D10s Pro is sold as:
 - Dreame D10s Pro
@@ -532,7 +532,7 @@ All warranty seals stay intact.
 
 ### D10s Plus <a id="dreame_d10splus"></a>
 
-<img src="./img/robots/dreame/dreame_d10splus.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/dreame/dreame_d10splus.jpg"/>
 
 The Dreame D10s Plus is sold as:
 - Dreame D10s Plus
@@ -557,7 +557,7 @@ MOVA apparently was a rather short-lived sub-brand(?) of Dreame
 
 ### MOVA Z500<a id="mova_z500"></a>
 
-<img src="./img/robots/mova/mova_z500.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/mova/mova_z500.jpg"/>
 
 The MOVA Z500 is made by Dreame. It is sold as:
 - MOVA Z500
@@ -581,7 +581,7 @@ All warranty seals stay intact.
 
 ### Roborock S5<a id="roborock_s5"></a>
 
-<img src="./img/robots/roborock/roborock_s5.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/roborock/roborock_s5.jpg"/>
 
 The Roborock S5 is sold as:
 - Roborock S5
@@ -604,7 +604,7 @@ Note that segment support is only available starting with firmware version 2008 
 
 ### Roborock S6<a id="roborock_s6"></a>
 
-<img src="./img/robots/roborock/roborock_s6.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/roborock/roborock_s6.jpg"/>
 
 The Roborock S6 is sold as:
 - Roborock S6
@@ -629,7 +629,7 @@ Rooting requires full disassembly.
 
 ### Roborock S6 Pure<a id="roborock_s6pure"></a>
 
-<img src="./img/robots/roborock/roborock_s6pure.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/roborock/roborock_s6pure.jpg"/>
 
 The Roborock S6 Pure is sold as:
 - Roborock S6 Pure
@@ -653,7 +653,7 @@ Rooting requires full disassembly.
 
 ### Roborock S4<a id="roborock_s4"></a>
 
-<img src="./img/robots/roborock/roborock_s4.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/roborock/roborock_s4.jpg"/>
 
 The Roborock S4 is sold as:
 - Roborock S4
@@ -677,7 +677,7 @@ Rooting requires full disassembly.
 
 ### Roborock S4 Max<a id="roborock_s4max"></a>
 
-<img src="./img/robots/roborock/roborock_s4max.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/roborock/roborock_s4max.jpg"/>
 
 The Roborock S4 Max is sold as:
 - Roborock S4 Max
@@ -701,7 +701,7 @@ Rooting requires full disassembly.
 
 ### Roborock S5 Max<a id="roborock_s5max"></a>
 
-<img src="./img/robots/roborock/roborock_s5max.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/roborock/roborock_s5max.jpg"/>
 
 The Roborock S5 Max is sold as:
 - Roborock S5 Max
@@ -722,7 +722,7 @@ Rooting requires full disassembly.
 
 ### Roborock S7<a id="roborock_s7"></a>
 
-<img src="./img/robots/roborock/roborock_s7.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/roborock/roborock_s7.jpg"/>
 
 The Roborock S7 is sold as:
 - Roborock S7
@@ -746,7 +746,7 @@ The VibraRise mop module makes disassembly of this robot difficult and easy to m
 
 ### Roborock S7 Pro Ultra<a id="roborock_s7proultra"></a>
 
-<img src="./img/robots/roborock/roborock_s7proultra.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/roborock/roborock_s7proultra.jpg"/>
 
 The Roborock S7 Pro Ultra is sold as:
 - Roborock S7 Pro Ultra
@@ -766,7 +766,7 @@ Rooting requires full disassembly.
 
 ### Roborock Q7 Max<a id="roborock_q7max"></a>
 
-<img src="./img/robots/roborock/roborock_q7max.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/roborock/roborock_q7max.jpg"/>
 
 The Roborock Q7 Max is sold as:
 - Roborock Q7 Max
@@ -792,7 +792,7 @@ They're not a robot manufacturer.
 
 ### Viomi V6<a id="viomi_v6"></a>
 
-<img src="./img/robots/viomi/viomi_v6.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/viomi/viomi_v6.jpg"/>
 
 The Viomi V6 is actually a 3irobotix CRL-200S inside. It is sold as:
 - Viomi Cleaning Robot
@@ -816,7 +816,7 @@ It might be required to remove the battery but that can be done without touching
 
 ### Viomi SE<a id="viomi_se"></a>
 
-<img src="./img/robots/viomi/viomi_se.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/viomi/viomi_se.jpg"/>
 
 The Viomi SE is actually a 3irobotix CRL-200S inside. It is sold as:
 - Viomi SE
@@ -844,7 +844,7 @@ They're not a robot manufacturer.<br/>
 
 ### Conga 3290<a id="conga_3290"></a>
 
-<img src="./img/robots/conga/conga_3290.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/conga/conga_3290.jpg"/>
 
 The Conga 3290 is actually a 3irobotix CRL-200S inside. It is sold as:
 - Conga 3290
@@ -869,7 +869,7 @@ It might be required to remove the battery but that can be done without touching
 
 ### Conga 3790<a id="conga_3790"></a>
 
-<img src="./img/robots/conga/conga_3790.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/conga/conga_3790.jpg"/>
 
 The Conga 3790 is actually a 3irobotix CRL-200S inside. It is sold as:
 - Conga 3790
@@ -900,7 +900,7 @@ They're not a robot manufacturer.<br/>
 
 ### Proscenic M6 Pro<a id="proscenic_m6pro"></a>
 
-<img src="./img/robots/proscenic/proscenic_m6pro.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/proscenic/proscenic_m6pro.jpg"/>
 
 The Proscenic M6 Pro is actually a 3irobotix CRL-200S inside. It is sold as:
 - Proscenic M6 Pro
@@ -931,7 +931,7 @@ Apparently, the first thing to do with that was to release a line of vacuum robo
 
 ### Commodore CVR 200<a id="commodore_cvr200"></a>
 
-<img src="./img/robots/commodore/commodore_cvr200.jpg"/>
+<img class="aspect-ratio-4" src="./img/robots/commodore/commodore_cvr200.jpg"/>
 
 The Commodore CVR 200 is actually a 3irobotix CRL-200S inside. It is sold as:
 - Commodore CVR 200

--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -289,6 +289,12 @@ th{
 img{
     max-width:100%
 }
+
+.aspect-ratio-4 {
+    width: 100%;
+    aspect-ratio: 4
+}
+
 header{
     width:270px;
     float:left;


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Docs
- [ ] Refactor/Code Cleanup

# Description

As discussed on Telegram I tried to fix the issue of anchors pointing to the wrong place on the supported robots page. I am relatively confident, that this fixes the issue, since in different browsers (Safari, Chrome, Firefox) and on throttled internet speeds it prevents the text from reflowing when the images are loaded. However reproducing the original bug of jumping to the wrong place proved to be difficult. I could somewhat consistently trigger it using an simulated iOS device after erasing all caches on it. I tried it several times with these changes and the issue did not occur, so I would say I am 90% certain that it works. 

I did not want to globally overwrite the image styling, so I added a class to all images on the page. The width must be explicitly specified or it doesn't work, thus I set it to 100%. The aspect ratio of the images does not seem to be exactly 4 in all cases, but it seems like its close enough, otherwise it would need to be set for every image individually.