### PR TITLE
Roborock gen4 mcuclock

### DIFF
--- a/backend/lib/NTPClient.js
+++ b/backend/lib/NTPClient.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const ntp = require("@destinationstransfers/ntp");
 
 const execSync = require("child_process").execSync;
@@ -29,6 +30,7 @@ class NTPClient {
         } else {
             this.state = new States.ValetudoNTPClientDisabledState({});
         }
+        this.busybox = fs.existsSync("/bin/busybox2") ? "/bin/busybox2" : "/bin/busybox";
 
         // On startup, we need to wait for a while for Valetudo to fully start up (at least when using pkg) or else
         // we will get ntp sync timeouts in the log due to something blocking the process for a while
@@ -157,7 +159,7 @@ class NTPClient {
             dateString += date.getSeconds().toString().padStart(2,0);
 
 
-            execSync("date -s \""+dateString+"\"");
+            execSync(this.busybox + " date -s \""+dateString+"\"");
 
             Logger.info("Successfully set the robot time via NTP to", date);
         } else {

--- a/backend/lib/Valetudo.js
+++ b/backend/lib/Valetudo.js
@@ -63,7 +63,8 @@ class Valetudo {
 
 
         this.ntpClient = new NTPClient({
-            config: this.config
+            config: this.config,
+            robot: this.robot
         });
 
         this.robot.startup();

--- a/backend/lib/core/capabilities/SetMCUTimeCapability.js
+++ b/backend/lib/core/capabilities/SetMCUTimeCapability.js
@@ -1,0 +1,27 @@
+const Capability = require("./Capability");
+const NotImplementedError = require("../NotImplementedError");
+
+/**
+ * @template {import("../ValetudoRobot")} T
+ * @extends Capability<T>
+ */
+class SetMCUTimeCapability extends Capability {
+    /**
+     * Sets the MCU time
+     *
+     * @abstract
+     * @param {Date} date
+     * @returns {Promise<void>}
+     */
+    async setTime(date) {
+        throw new NotImplementedError();
+    }
+
+    getType() {
+        return SetMCUTimeCapability.TYPE;
+    }
+}
+
+SetMCUTimeCapability.TYPE = "SetMCUTimeCapability";
+
+module.exports = SetMCUTimeCapability;

--- a/backend/lib/core/capabilities/index.js
+++ b/backend/lib/core/capabilities/index.js
@@ -29,6 +29,7 @@ module.exports = {
     PetObstacleAvoidanceControlCapability: require("./PetObstacleAvoidanceControlCapability"),
     PresetSelectionCapability: require("./PresetSelectionCapability"),
     QuirksCapability: require("./QuirksCapability"),
+    SetMCUTimeCapability: require("./SetMCUTimeCapability"),
     SpeakerTestCapability: require("./SpeakerTestCapability"),
     SpeakerVolumeControlCapability: require("./SpeakerVolumeControlCapability"),
     TotalStatisticsCapability: require("./TotalStatisticsCapability"),

--- a/backend/lib/miio/MiioSocket.js
+++ b/backend/lib/miio/MiioSocket.js
@@ -187,9 +187,11 @@ class MiioSocket {
 
             /*
                 If a message has a result or error property, it is a response to a request from the robot,
+                local.* or _internal.* is a response with params instead of result,
                 meaning that we should not add it to our pending requests
              */
-            if (msg !== null && msg !== undefined && !msg["result"] && !msg["error"]) {
+            const pending = (msg !== null && msg !== undefined && !msg["result"] && !msg["error"] && !msg["method"].startsWith("local.") && !msg["method"].startsWith("_internal."));
+            if (pending) {
                 const msgId = msg["id"];
 
                 this.pendingRequests[msgId] = {
@@ -223,6 +225,10 @@ class MiioSocket {
 
             Logger.debug(">>> " + this.name + ":", msg);
             this.socket.send(packet, 0, packet.length, this.rinfo.port, this.rinfo.address);
+
+            if (!pending) {
+                resolve();
+            }
         });
     }
 

--- a/backend/lib/robots/roborock/RoborockGen4ValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockGen4ValetudoRobot.js
@@ -103,7 +103,8 @@ class RoborockGen4ValetudoRobot extends RoborockValetudoRobot {
             capabilities.RoborockMultiMapMapResetCapability,
             capabilities.RoborockMapSegmentationCapability,
             capabilities.RoborockMapSegmentEditCapability,
-            capabilities.RoborockMapSegmentRenameCapability
+            capabilities.RoborockMapSegmentRenameCapability,
+            capabilities.RoborockSetMCUTimeCapability
         ].forEach(capability => {
             this.registerCapability(new capability({robot: this}));
         });

--- a/backend/lib/robots/roborock/capabilities/RoborockSetMCUTimeCapability.js
+++ b/backend/lib/robots/roborock/capabilities/RoborockSetMCUTimeCapability.js
@@ -1,0 +1,18 @@
+const SetMCUTimeCapability = require("../../../core/capabilities/SetMCUTimeCapability");
+
+/**
+ * @extends SetMCUTimeCapability<import("../RoborockValetudoRobot")>
+ */
+class RoborockSetMCUTimeCapability extends SetMCUTimeCapability {
+    /**
+     * Sets the MCU time
+     *
+     * @param {Date} date
+     * @returns {Promise<void>}
+     */
+    async setTime(date) {
+        await this.robot.sendCommand("local.time", [Math.floor(date.valueOf() / 1000)], {});
+    }
+}
+
+module.exports = RoborockSetMCUTimeCapability;

--- a/backend/lib/robots/roborock/capabilities/index.js
+++ b/backend/lib/robots/roborock/capabilities/index.js
@@ -27,6 +27,7 @@ module.exports = {
     RoborockObstacleAvoidanceControlCapability: require("./RoborockObstacleAvoidanceControlCapability"),
     RoborockPersistentMapControlCapability: require("./RoborockPersistentMapControlCapability"),
     RoborockPetObstacleAvoidanceControlCapability: require("./RoborockPetObstacleAvoidanceControlCapability"),
+    RoborockSetMCUTimeCapability: require("./RoborockSetMCUTimeCapability"),
     RoborockSpeakerTestCapability: require("./RoborockSpeakerTestCapability"),
     RoborockSpeakerVolumeControlCapability: require("./RoborockSpeakerVolumeControlCapability"),
     RoborockTotalStatisticsCapability: require("./RoborockTotalStatisticsCapability"),

--- a/backend/lib/webserver/CapabilitiesRouter.js
+++ b/backend/lib/webserver/CapabilitiesRouter.js
@@ -64,6 +64,7 @@ const CAPABILITY_TYPE_TO_ROUTER_MAPPING = {
     [capabilities.ManualControlCapability.TYPE]: capabilityRouters.ManualControlCapabilityRouter,
     [capabilities.CombinedVirtualRestrictionsCapability.TYPE]: capabilityRouters.CombinedVirtualRestrictionsCapabilityRouter,
     [capabilities.PersistentMapControlCapability.TYPE]: capabilityRouters.SimpleToggleCapabilityRouter,
+    [capabilities.SetMCUTimeCapability.TYPE]: capabilityRouters.DummyCapabilityRouter,
     [capabilities.SpeakerVolumeControlCapability.TYPE]: capabilityRouters.SpeakerVolumeControlCapabilityRouter,
     [capabilities.MapSegmentationCapability.TYPE]: capabilityRouters.MapSegmentationCapabilityRouter,
     [capabilities.DoNotDisturbCapability.TYPE]: capabilityRouters.DoNotDisturbCapabilityRouter,

--- a/backend/lib/webserver/capabilityRouters/DummyCapabilityRouter.js
+++ b/backend/lib/webserver/capabilityRouters/DummyCapabilityRouter.js
@@ -1,0 +1,9 @@
+const CapabilityRouter = require("./CapabilityRouter");
+
+class DummyCapabilityRouter extends CapabilityRouter {
+    initRoutes() {
+        //intentional
+    }
+}
+
+module.exports = DummyCapabilityRouter;

--- a/backend/lib/webserver/capabilityRouters/index.js
+++ b/backend/lib/webserver/capabilityRouters/index.js
@@ -5,6 +5,7 @@ module.exports = {
     CombinedVirtualRestrictionsCapabilityRouter: require("./CombinedVirtualRestrictionsCapabilityRouter"),
     ConsumableMonitoringCapabilityRouter: require("./ConsumableMonitoringCapabilityRouter"),
     DoNotDisturbCapabilityRouter: require("./DoNotDisturbCapabilityRouter"),
+    DummyCapabilityRouter: require("./DummyCapabilityRouter"),
     GoToLocationCapabilityRouter: require("./GoToLocationCapabilityRouter"),
     LocateCapabilityRouter: require("./LocateCapabilityRouter"),
     ManualControlCapabilityRouter: require("./ManualControlCapabilityRouter"),


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs
- [ ] Refactor/Code Cleanup
- [X] Vendor feature

# Description
Sync system time to mcu, which help restoring correct time when booting (and maybe other mcu time relative behavior)

1. in G10s(and pro), vendor busybox date does not allow setting system time, use busybox2 provided by dennis in the rooted system image
2. fake a local.time from Valetudo (as cloud) to AppProxy which then sent to miio_client etc, triggering mcu time sync vendor code. This method works, confirmed by testing on hardware and by reverse engineering of AppProxy/miio_client (etc) binary