### PR TITLE
feat(vendor.roborock): new fan speed and mop patterns for Gen4 robots

### DIFF
--- a/backend/lib/robots/roborock/RoborockGen4ValetudoRobot.js
+++ b/backend/lib/robots/roborock/RoborockGen4ValetudoRobot.js
@@ -204,6 +204,7 @@ const FAN_SPEEDS = {
     [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.MEDIUM]: 102,
     [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.HIGH]: 103,
     [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.MAX]: 104,
+    [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.TURBO]: 108,
     [entities.state.attributes.PresetSelectionStateAttribute.INTENSITY.OFF] : 105 //also known as mop mode
 };
 

--- a/backend/lib/robots/roborock/RoborockQuirkFactory.js
+++ b/backend/lib/robots/roborock/RoborockQuirkFactory.js
@@ -259,7 +259,7 @@ class RoborockQuirkFactory {
                     id: id,
                     title: "Mop Pattern",
                     description: "Select which movement mode to use while mopping.",
-                    options: ["standard", "deep"],
+                    options: ["fast", "standard", "deep", "deep+", "customize"],
                     getter: async () => {
                         const res = await this.robot.sendCommand("get_mop_mode", [], {});
 
@@ -268,6 +268,12 @@ class RoborockQuirkFactory {
                                 return "standard";
                             case 301:
                                 return "deep";
+                            case 302:
+                                return "customize";
+                            case 303:
+                                return "deep+";
+                            case 304:
+                                return "fast";
                             default:
                                 throw new Error(`Received invalid value ${res?.[0]}`);
                         }
@@ -281,6 +287,15 @@ class RoborockQuirkFactory {
                                 break;
                             case "deep":
                                 val = 301;
+                                break;
+                            case "customize":
+                                val = 302;
+                                break;
+                            case "deep+":
+                                val = 303;
+                                break;
+                            case "fast":
+                                val = 304;
                                 break;
                             default:
                                 throw new Error(`Received invalid value ${value}`);


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs
- [ ] Refactor/Code Cleanup
- [X] Vendor Feature

# Description
adds TURBO speed and "fast" "deep+" "customize" mop patterns for Gen4 roborock.
this patch ignore the old "less featured" mop pattern of roborock assuming all options are supported to keep the code simple. otherwise should copy the quirk as old/new versions