### PR TITLE
chore(dev): allow specify apiBaseUrl testing, allow CROS origin in co…

### DIFF
--- a/backend/lib/doc/Configuration.openapi.json
+++ b/backend/lib/doc/Configuration.openapi.json
@@ -41,6 +41,9 @@
               },
               "blockExternalAccess": {
                 "type": "boolean"
+              },
+              "allowOrigin": {
+                "type": "string"
               }
             }
           },

--- a/backend/lib/res/default_config.json
+++ b/backend/lib/res/default_config.json
@@ -13,7 +13,8 @@
             "username": "valetudo",
             "password": "valetudo"
         },
-        "blockExternalAccess": true
+        "blockExternalAccess": true,
+        "allowOrigin": "http://localhost/"
     },
     "mqtt": {
         "enabled": false,

--- a/backend/lib/webserver/WebServer.js
+++ b/backend/lib/webserver/WebServer.js
@@ -70,6 +70,18 @@ class WebServer {
         if (this.webserverConfig.blockExternalAccess) {
             this.app.use(Middlewares.ExternalAccessCheckMiddleware);
         }
+        if (this.webserverConfig.allowOrigin) {
+            this.app.use(function (req, res, next) {
+                const origin = req.headers["origin"];
+                if (origin?.startsWith(self.webserverConfig.allowOrigin)) {
+                    res.setHeader("Access-Control-Allow-Origin", origin);
+                    res.setHeader("Access-Control-Allow-Credentials", "true");
+                    res.setHeader("Access-Control-Allow-Methods", "*");
+                    res.setHeader("Access-Control-Allow-Headers", "*");
+                }
+                next();
+            });
+        }
 
         const authMiddleware = this.createAuthMiddleware();
         const dynamicAuth = dynamicMiddleware.create([]);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -64,8 +64,9 @@ import { floorObject } from "./utils";
 import {preprocessMap} from "./mapUtils";
 import ReconnectingEventSource from "reconnecting-eventsource";
 
+const parsedUrl = new URL(window.location.toString());
 export const valetudoAPI = axios.create({
-    baseURL: "./api/v2",
+    baseURL: parsedUrl.searchParams.get("apiBaseUrl") ?? "./api/v2",
 });
 
 let currentCommitId = "unknown";


### PR DESCRIPTION
…nfig

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs
- [X] Refactor/Code Cleanup

# Description
allow frontend page (running on development pc) to cross use backend running on robot device, by "apiBaseUrl=http://roboturl"
for new roborock robots, it's not easy to make the robot connect valetudo cloud running outside of robot (development PC), because rootfs is readonly, mount bind is disabled, and ip is checked