### PR TITLE
Tip on where to find the specific topic of your vacuum cleaner

### DIFF
--- a/docs/_pages/integrations/home-assistant-integration.md
+++ b/docs/_pages/integrations/home-assistant-integration.md
@@ -24,6 +24,7 @@ For more information about how the MQTT discovery works, check out the [Home Ass
 
 These examples are written for a hypothetical Valetudo-enabled Robot with the System ID `JustForDemonstration`.<br/>
 They need to be adapted to your System ID that can be found on the *System Information* page of your Valetudo instance.
+The exact topic name can also be found by going to Connectivity - MQTT Connectivity.
 
 #### Basic Services
 

--- a/docs/_pages/integrations/mqtt.md
+++ b/docs/_pages/integrations/mqtt.md
@@ -8,6 +8,7 @@ order: 20
 
 To make your robot talk to your MQTT broker and integrate with home automation software, such as but not limited to
 Home Assistant, openHAB and Node-RED, configure MQTT via Valetudo's web interface (Connectivity → MQTT connectivity).
+On this page you can also find the exact topic to which to send commands to or from.
 
 ## Autodiscovery
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Docs
- [ ] Refactor/Code Cleanup

# Description

This PR mentions on 2 places where to find the actual topic on which your valetudo instance will publish and listen to MQTT messages.

My motivation comes from the fact that I found out about this by wandering about in the valetudo instance, if it was mentioned directly in the documentation it could have saved me about 1 minute of clicking around.