### PR TITLE
Remove deprecated payload template

### DIFF
--- a/docs/_pages/integrations/home-assistant-integration.md
+++ b/docs/_pages/integrations/home-assistant-integration.md
@@ -198,7 +198,7 @@ vacuum_clean_segments_message:
   - service: mqtt.publish
     data:
       topic: valetudo/JustForDemonstration/MapSegmentationCapability/clean/set
-      payload_template: '{"segment_ids": {{segments}}}'
+      payload: '{"segment_ids": {{segments}}}'
   mode: single
 {% endraw %}
 ```


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Docs
- [ ] Refactor/Code Cleanup

# Description

The payload template is depracted by HA and will be removed in 2025.2.0
 
<!-- Delete if there is none -->
Fixes # (issue)