### PR TITLE
Update home-assistant-integration.md

### DIFF
--- a/docs/_pages/integrations/home-assistant-integration.md
+++ b/docs/_pages/integrations/home-assistant-integration.md
@@ -198,7 +198,7 @@ vacuum_clean_segments_message:
   - service: mqtt.publish
     data:
       topic: valetudo/JustForDemonstration/MapSegmentationCapability/clean/set
-      payload_template: '{"segment_ids": {{segments}}}'
+      payload: '{"segment_ids": {{segments}}}'
   mode: single
 {% endraw %}
 ```


### PR DESCRIPTION
Deprecated payload_template option used in MQTT publish action call

https://github.com/home-assistant/core/pull/122098

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Docs
- [ ] Refactor/Code Cleanup

# Description

Please include a summary of the change and which issue is fixed (if applicable).
Please also include relevant motivation and context.
 