### PR TITLE
Default NTP Server

### DIFF
--- a/backend/lib/res/default_config.json
+++ b/backend/lib/res/default_config.json
@@ -59,7 +59,7 @@
     },
     "ntpClient": {
         "enabled": true,
-        "server": "valetudo.pool.ntp.org",
+        "server": "pool.ntp.org",
         "port": 123,
         "interval": 28800000,
         "timeout": 10000


### PR DESCRIPTION
The default ntpClient `valetudo.pool.ntp.org` is/was unreachable and I needed to manually change it to `pool.ntp.org`.
To prevent connectivity issues, the default server should remain `pool.ntp.org`.
