### PR TITLE
feat: Expose current segment location to Home Assistant

### DIFF
--- a/backend/lib/entities/map/ValetudoMap.js
+++ b/backend/lib/entities/map/ValetudoMap.js
@@ -1,6 +1,7 @@
 const crypto = require("crypto");
 
 const MapLayer = require("./MapLayer");
+const PointMapEntity = require("./PointMapEntity");
 const SerializableEntity = require("../SerializableEntity");
 const ValetudoMapSegment = require("../core/ValetudoMapSegment");
 
@@ -105,6 +106,80 @@ class ValetudoMap extends SerializableEntity { //TODO: Current, Historic, Etc.
                     name: e.metaData.name
                 });
             });
+    }
+
+    /**
+     * Find the segment at a given absolute position in cm.
+     * Returns {id, name} or null if not found.
+     *
+     * @public
+     * @param {number} xCm
+     * @param {number} yCm
+     * @returns {{id: string, name: string}|null}
+     */
+    getSegmentAtPoint(xCm, yCm) {
+        if (typeof xCm !== "number" || typeof yCm !== "number" || typeof this.pixelSize !== "number") {
+            return null;
+        }
+
+        const px = Math.round(xCm / this.pixelSize);
+        const py = Math.round(yCm / this.pixelSize);
+
+        for (const layer of this.layers) {
+            if (!layer || layer.type !== MapLayer.TYPE.SEGMENT || !layer.metaData || !Array.isArray(layer.compressedPixels)) {
+                continue;
+            }
+
+            const dims = layer.dimensions;
+            if (!dims) {
+                continue;
+            }
+
+            if (px < dims.x.min || px > dims.x.max || py < dims.y.min || py > dims.y.max) {
+                continue;
+            }
+
+            const cp = layer.compressedPixels; // [xStart, y, count] triplets
+            for (let i = 0; i < cp.length; i += 3) {
+                const xStart = cp[i];
+                const y = cp[i + 1];
+                const count = cp[i + 2];
+
+                if (y === py) {
+                    if (px >= xStart && px < xStart + count) {
+                        const id = typeof layer.metaData.segmentId === "number" ? layer.metaData.segmentId.toString() : layer.metaData.segmentId;
+                        const name = layer.metaData.name ?? id ?? "";
+
+                        if (id) {
+                            return {id: id, name: name};
+                        }
+                    }
+                } else if (y > py) {
+                    break;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Return the segment at the current robot position, if available.
+     * Returns {id, name} or null.
+     *
+     * @public
+     * @returns {{id: string, name: string}|null}
+     */
+    getRobotPositionSegment() {
+        const robotPos = this.entities.find(e => {
+            return e && e.type === PointMapEntity.TYPE.ROBOT_POSITION && Array.isArray(e.points) && e.points.length === 2;
+        });
+
+        if (!robotPos) {
+            return null;
+        }
+
+        return this.getSegmentAtPoint(robotPos.points[0], robotPos.points[1]);
     }
 }
 

--- a/backend/lib/mqtt/handles/MapNodeMqttHandle.js
+++ b/backend/lib/mqtt/handles/MapNodeMqttHandle.js
@@ -128,6 +128,71 @@ class MapNodeMqttHandle extends NodeMqttHandle {
                 })
             );
         });
+
+        // Current segment (room) the robot is in, derived from map + position
+        this.registerChild(
+            new PropertyMqttHandle({
+                parent: this,
+                controller: this.controller,
+                topicName: "current-segment-id",
+                friendlyName: "Current segment id",
+                datatype: DataType.STRING,
+                format: "plain segment id or empty",
+                getter: async () => {
+                    const seg = this.robot.state.map?.getRobotPositionSegment?.();
+                    return seg?.id ?? "";
+                },
+                helpText: "Segment id at the robot's current position. Empty when unknown."
+            }).also((prop) => {
+                this.controller.withHass((hass) => {
+                    prop.attachHomeAssistantComponent(
+                        new InLineHassComponent({
+                            hass: hass,
+                            robot: this.robot,
+                            name: "MapCurrentSegmentId",
+                            friendlyName: "Current segment id",
+                            componentType: ComponentType.SENSOR,
+                            autoconf: {
+                                state_topic: prop.getBaseTopic(),
+                                icon: "mdi:format-list-numbered"
+                            }
+                        })
+                    );
+                });
+            })
+        );
+
+        this.registerChild(
+            new PropertyMqttHandle({
+                parent: this,
+                controller: this.controller,
+                topicName: "current-segment-name",
+                friendlyName: "Current segment name",
+                datatype: DataType.STRING,
+                format: "plain segment name or empty",
+                getter: async () => {
+                    const seg = this.robot.state.map?.getRobotPositionSegment?.();
+                    return seg?.name ?? "";
+                },
+                helpText: "Segment name at the robot's current position. Empty when unknown."
+            }).also((prop) => {
+                this.controller.withHass((hass) => {
+                    prop.attachHomeAssistantComponent(
+                        new InLineHassComponent({
+                            hass: hass,
+                            robot: this.robot,
+                            name: "MapCurrentSegmentName",
+                            friendlyName: "Current segment name",
+                            componentType: ComponentType.SENSOR,
+                            autoconf: {
+                                state_topic: prop.getBaseTopic(),
+                                icon: "mdi:label"
+                            }
+                        })
+                    );
+                });
+            })
+        );
     }
 
     /**


### PR DESCRIPTION
# Summary

- Adds two read-only sensors:
    - current-segment-id
    - current-segment-name
- Values are empty if the robot’s position can’t be mapped to a segment (no map/pose, off-map, or unsegmented).

# Motivation

- Enables simple, dependable segment-based automations without changing core behavior.
- Example automations:
    - Modify water/fan/vacuum mode based on the current room (e.g., increase water on tile; reduce water on parquet).
    - Turn hallway lights to a warning color to avoid slamming the door into the vacuum.
    - Automatically raise a standing desk in the study room when the vacuum enters to prevent cable snags.
    - Close the patio door so the vacuum doesn’t escape.


# Testing

Tested on a Dreame L10s; works in moving mode and cleaning mode.

## Screenshots

<img width="558" height="613" alt="image" src="https://github.com/user-attachments/assets/054e3282-84fb-4d73-a907-afc6e38b24fe" />

<img width="561" height="594" alt="image" src="https://github.com/user-attachments/assets/cdaa1d5b-fd3e-4ede-a821-bb01ea70f962" />


# Why Merge

Exposing the current segment id/name is a narrowly scoped, read‑only addition that doesn’t alter core behavior or broaden the project’s scope; it simply surfaces existing state.

This improves dependability and observability for common segment‑based automations while reducing user guesswork.

The change is backwards‑compatible, low‑risk, and low‑maintenance, aligning with the project’s preference for minimal code that benefits the mainstream use case rather than niche workflows.